### PR TITLE
Add LLM categorization service and configuration UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+packages/web-extension/dist/

--- a/packages/web-extension/manifest.json
+++ b/packages/web-extension/manifest.json
@@ -12,5 +12,8 @@
   "permissions": [
     "bookmarks",
     "storage"
+  ],
+  "host_permissions": [
+    "https://api.openai.com/*"
   ]
 }

--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@capybara/web-extension",
+  "version": "0.0.1",
+  "private": true,
+  "type": "commonjs",
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "test": "npm run build --silent && node --test dist/domain/services/__tests__/*.test.js"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/packages/web-extension/src/background/index.ts
+++ b/packages/web-extension/src/background/index.ts
@@ -1,5 +1,5 @@
 import { mergeBookmarks } from "../domain/services/merger";
-import { categorizeBookmarks } from "../domain/services/categorizer";
+import { categorizeBookmarksWithLLM } from "../domain/services/llm-categorizer";
 import { searchBookmarks } from "../domain/services/search";
 import { fetchChromiumBookmarks } from "./bookmark-sync/chromium-provider";
 import { fetchFirefoxBookmarks } from "./bookmark-sync/firefox-provider";
@@ -11,6 +11,6 @@ export async function synchronizeBookmarks(): Promise<void> {
   ]);
 
   const merged = mergeBookmarks(chromiumBookmarks, firefoxBookmarks);
-  const categorized = categorizeBookmarks(merged);
+  const categorized = await categorizeBookmarksWithLLM(merged);
   searchBookmarks.index(categorized);
 }

--- a/packages/web-extension/src/domain/models/llm-configuration.ts
+++ b/packages/web-extension/src/domain/models/llm-configuration.ts
@@ -1,0 +1,8 @@
+export interface LLMConfiguration {
+  enabled: boolean;
+  endpoint: string;
+  apiKey: string;
+  model?: string;
+}
+
+export const LLM_CONFIGURATION_STORAGE_KEY = "llmConfiguration";

--- a/packages/web-extension/src/domain/services/__tests__/categorizer.test.ts
+++ b/packages/web-extension/src/domain/services/__tests__/categorizer.test.ts
@@ -1,0 +1,54 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { Bookmark } from "../../models/bookmark";
+import { categorizeBookmarks } from "../categorizer";
+
+describe("categorizeBookmarks", () => {
+  it("prefers the first tag when available", () => {
+    const bookmarks: Bookmark[] = [
+      {
+        id: "bookmark-1",
+        title: "A guide to sourdough",
+        url: "https://bread.example.com/guide",
+        tags: ["baking", "food"],
+        createdAt: "2024-01-01T00:00:00.000Z"
+      }
+    ];
+
+    const categorized = categorizeBookmarks(bookmarks);
+
+    assert.strictEqual(categorized[0].category, "baking");
+  });
+
+  it("falls back to the hostname when tags are missing", () => {
+    const bookmarks: Bookmark[] = [
+      {
+        id: "bookmark-2",
+        title: "Infrastructure patterns",
+        url: "https://engineering.example.org/posts/1",
+        tags: [],
+        createdAt: "2024-01-02T00:00:00.000Z"
+      }
+    ];
+
+    const categorized = categorizeBookmarks(bookmarks);
+
+    assert.strictEqual(categorized[0].category, "example.org");
+  });
+
+  it("marks bookmarks as uncategorized when parsing fails", () => {
+    const bookmarks: Bookmark[] = [
+      {
+        id: "bookmark-3",
+        title: "Broken link",
+        url: "not-a-valid-url",
+        tags: [],
+        createdAt: "2024-01-03T00:00:00.000Z"
+      }
+    ];
+
+    const categorized = categorizeBookmarks(bookmarks);
+
+    assert.strictEqual(categorized[0].category, "uncategorized");
+  });
+});

--- a/packages/web-extension/src/domain/services/__tests__/llm-categorizer.test.ts
+++ b/packages/web-extension/src/domain/services/__tests__/llm-categorizer.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { Bookmark } from "../../models/bookmark";
+import { categorizeBookmarksWithLLM } from "../llm-categorizer";
+
+type MockFetchCall = [string, RequestInit?];
+
+type MockResponse = {
+  ok: boolean;
+  status?: number;
+  json: () => Promise<unknown>;
+};
+
+const bookmarks: Bookmark[] = [
+  {
+    id: "bookmark-1",
+    title: "Machine Learning Weekly",
+    url: "https://ml.example.com/articles/1",
+    tags: [],
+    createdAt: "2024-01-01T00:00:00.000Z"
+  },
+  {
+    id: "bookmark-2",
+    title: "Cooking with Herbs",
+    url: "https://food.example.com/herbs",
+    tags: ["cooking"],
+    createdAt: "2024-01-02T00:00:00.000Z"
+  }
+];
+
+function mockStorage(configuration: unknown): void {
+  const get = async (): Promise<Record<string, unknown>> => ({
+    llmConfiguration: configuration
+  });
+
+  (globalThis as { browser?: unknown }).browser = {
+    storage: {
+      local: {
+        get,
+        set: async () => {}
+      }
+    }
+  };
+}
+
+function mockFetch(impl: (...args: MockFetchCall) => Promise<MockResponse>) {
+  const calls: MockFetchCall[] = [];
+  const fetchMock = async (input: string, init?: RequestInit): Promise<MockResponse> => {
+    const call: MockFetchCall = [input, init];
+    calls.push(call);
+    return impl(input, init);
+  };
+
+  (globalThis as { fetch?: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
+  return { calls };
+}
+
+afterEach(() => {
+  delete (globalThis as { browser?: unknown }).browser;
+  delete (globalThis as { fetch?: unknown }).fetch;
+});
+
+describe("categorizeBookmarksWithLLM", () => {
+  it("maps LLM responses onto categorized bookmarks", async () => {
+    mockStorage({
+      enabled: true,
+      endpoint: "https://api.openai.com/v1/bookmarks",
+      apiKey: "api-key",
+      model: "bookmark-model"
+    });
+
+    const { calls } = mockFetch(async () => ({
+      ok: true,
+      json: async () => ({
+        categories: [
+          { id: "bookmark-1", category: "machine-learning" },
+          { id: "bookmark-2", category: "cooking" }
+        ]
+      })
+    }));
+
+    const categorized = await categorizeBookmarksWithLLM(bookmarks);
+
+    assert.strictEqual(calls.length, 1);
+    const [url, init] = calls[0];
+    assert.strictEqual(url, "https://api.openai.com/v1/bookmarks");
+    assert.ok(init);
+    assert.strictEqual(init?.method, "POST");
+    assert.deepStrictEqual(init?.headers, {
+      Authorization: "Bearer api-key",
+      "Content-Type": "application/json"
+    });
+
+    const payload = JSON.parse((init?.body ?? "{}") as string) as Record<string, unknown>;
+    assert.ok(Array.isArray(payload.bookmarks));
+    assert.strictEqual(payload.model, "bookmark-model");
+
+    assert.deepStrictEqual(categorized, [
+      {
+        ...bookmarks[0],
+        category: "machine-learning"
+      },
+      {
+        ...bookmarks[1],
+        category: "cooking"
+      }
+    ]);
+  });
+
+  it("falls back to heuristic categories when the feature is disabled", async () => {
+    mockStorage({ enabled: false, endpoint: "https://api.openai.com", apiKey: "token" });
+
+    const { calls } = mockFetch(async () => ({
+      ok: true,
+      json: async () => ({ categories: [] })
+    }));
+
+    const categorized = await categorizeBookmarksWithLLM(bookmarks);
+
+    assert.strictEqual(calls.length, 0);
+    assert.deepStrictEqual(
+      categorized.map((bookmark) => bookmark.category),
+      ["example.com", "cooking"]
+    );
+  });
+
+  it("falls back to heuristic categories when the LLM request fails", async () => {
+    mockStorage({ enabled: true, endpoint: "https://api.openai.com", apiKey: "token" });
+
+    const { calls } = mockFetch(async () => ({
+      ok: false,
+      status: 500,
+      json: async () => ({})
+    }));
+
+    const categorized = await categorizeBookmarksWithLLM(bookmarks);
+
+    assert.strictEqual(calls.length, 1);
+    assert.deepStrictEqual(
+      categorized.map((bookmark) => bookmark.category),
+      ["example.com", "cooking"]
+    );
+  });
+
+  it("uses heuristic values for bookmarks missing in the LLM response", async () => {
+    mockStorage({ enabled: true, endpoint: "https://api.openai.com", apiKey: "token" });
+
+    mockFetch(async () => ({
+      ok: true,
+      json: async () => ({
+        categories: [{ id: "bookmark-1", category: "ai" }]
+      })
+    }));
+
+    const categorized = await categorizeBookmarksWithLLM(bookmarks);
+
+    assert.deepStrictEqual(categorized, [
+      {
+        ...bookmarks[0],
+        category: "ai"
+      },
+      {
+        ...bookmarks[1],
+        category: "cooking"
+      }
+    ]);
+  });
+});

--- a/packages/web-extension/src/domain/services/llm-categorizer.ts
+++ b/packages/web-extension/src/domain/services/llm-categorizer.ts
@@ -1,0 +1,113 @@
+import type { Bookmark } from "../models/bookmark";
+import type { LLMConfiguration } from "../models/llm-configuration";
+import { categorizeBookmarks, type CategorizedBookmark } from "./categorizer";
+import { loadLLMConfiguration } from "./llm-settings";
+
+interface LLMRequestPayload {
+  bookmarks: Array<Pick<Bookmark, "id" | "title" | "url" | "tags">>;
+  model?: string;
+}
+
+interface LLMResponsePayload {
+  categories: Array<{ id: string; category: string }>;
+}
+
+function buildHeaders(configuration: LLMConfiguration): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json"
+  };
+
+  const apiKey = configuration.apiKey.trim();
+  if (apiKey.length > 0) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+
+  return headers;
+}
+
+function parseResponse(payload: unknown): LLMResponsePayload | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  const value = payload as Partial<LLMResponsePayload>;
+  if (!Array.isArray(value.categories)) {
+    return null;
+  }
+
+  const categories = value.categories.filter((item): item is { id: string; category: string } => {
+    return Boolean(item) && typeof item.id === "string" && typeof item.category === "string";
+  });
+
+  if (categories.length === 0) {
+    return null;
+  }
+
+  return { categories };
+}
+
+export async function categorizeBookmarksWithLLM(
+  bookmarks: Bookmark[]
+): Promise<CategorizedBookmark[]> {
+  if (bookmarks.length === 0) {
+    return [];
+  }
+
+  const fallbackCategorized = categorizeBookmarks(bookmarks);
+
+  try {
+    const configuration = await loadLLMConfiguration();
+    if (!configuration) {
+      return fallbackCategorized;
+    }
+
+    const endpoint = configuration.endpoint.trim();
+    const apiKey = configuration.apiKey.trim();
+
+    if (!configuration.enabled || endpoint.length === 0 || apiKey.length === 0) {
+      return fallbackCategorized;
+    }
+
+    const payload: LLMRequestPayload = {
+      bookmarks: bookmarks.map((bookmark) => ({
+        id: bookmark.id,
+        title: bookmark.title,
+        url: bookmark.url,
+        tags: bookmark.tags
+      }))
+    };
+
+    if (configuration.model && configuration.model.trim().length > 0) {
+      payload.model = configuration.model.trim();
+    }
+
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: buildHeaders(configuration),
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      throw new Error(`LLM request failed with status ${response.status}`);
+    }
+
+    const parsed = parseResponse(await response.json());
+    if (!parsed) {
+      throw new Error("LLM response payload was malformed");
+    }
+
+    const categoryById = new Map(parsed.categories.map((item) => [item.id, item.category]));
+
+    return fallbackCategorized.map((bookmark) => {
+      const category = categoryById.get(bookmark.id);
+      if (!category || category.trim().length === 0) {
+        return bookmark;
+      }
+
+      return { ...bookmark, category };
+    });
+  } catch (error) {
+    console.warn("Falling back to heuristic categorizer due to LLM error", error);
+    return fallbackCategorized;
+  }
+}

--- a/packages/web-extension/src/domain/services/llm-settings.ts
+++ b/packages/web-extension/src/domain/services/llm-settings.ts
@@ -1,0 +1,27 @@
+import { LLM_CONFIGURATION_STORAGE_KEY, type LLMConfiguration } from "../models/llm-configuration";
+
+function normalizeConfiguration(raw: unknown): LLMConfiguration | null {
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+
+  const value = raw as Partial<LLMConfiguration>;
+
+  return {
+    enabled: Boolean(value.enabled),
+    endpoint: typeof value.endpoint === "string" ? value.endpoint : "",
+    apiKey: typeof value.apiKey === "string" ? value.apiKey : "",
+    model: typeof value.model === "string" ? value.model : undefined
+  };
+}
+
+export async function loadLLMConfiguration(): Promise<LLMConfiguration | null> {
+  const stored = await browser.storage.local.get(LLM_CONFIGURATION_STORAGE_KEY);
+  return normalizeConfiguration(stored[LLM_CONFIGURATION_STORAGE_KEY]);
+}
+
+export async function saveLLMConfiguration(configuration: LLMConfiguration): Promise<void> {
+  await browser.storage.local.set({
+    [LLM_CONFIGURATION_STORAGE_KEY]: configuration
+  });
+}

--- a/packages/web-extension/src/domain/services/search.ts
+++ b/packages/web-extension/src/domain/services/search.ts
@@ -1,15 +1,15 @@
 import { CategorizedBookmark } from "./categorizer";
 
 class SearchIndex {
-  private index: CategorizedBookmark[] = [];
+  private items: CategorizedBookmark[] = [];
 
   public index(bookmarks: CategorizedBookmark[]): void {
-    this.index = bookmarks;
+    this.items = bookmarks;
   }
 
   public query(term: string): CategorizedBookmark[] {
     const normalizedTerm = term.toLowerCase();
-    return this.index.filter((bookmark) => {
+    return this.items.filter((bookmark) => {
       return (
         bookmark.title.toLowerCase().includes(normalizedTerm) ||
         bookmark.url.toLowerCase().includes(normalizedTerm) ||

--- a/packages/web-extension/src/options/settings.tsx
+++ b/packages/web-extension/src/options/settings.tsx
@@ -1,7 +1,69 @@
-import { useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
+import { LLM_CONFIGURATION_STORAGE_KEY, type LLMConfiguration } from "../domain/models/llm-configuration";
+import { loadLLMConfiguration, saveLLMConfiguration } from "../domain/services/llm-settings";
 
 export function Settings(): JSX.Element {
   const [syncEnabled, setSyncEnabled] = useState(true);
+  const [llmEnabled, setLlmEnabled] = useState(false);
+  const [llmEndpoint, setLlmEndpoint] = useState("");
+  const [llmApiKey, setLlmApiKey] = useState("");
+  const [llmModel, setLlmModel] = useState("");
+  const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
+
+  useEffect(() => {
+    let active = true;
+
+    async function hydrateConfiguration(): Promise<void> {
+      const configuration = await loadLLMConfiguration();
+      if (!active) {
+        return;
+      }
+
+      if (configuration) {
+        applyConfiguration(configuration);
+      } else {
+        applyConfiguration({
+          enabled: false,
+          endpoint: "",
+          apiKey: ""
+        });
+      }
+    }
+
+    function applyConfiguration(configuration: LLMConfiguration): void {
+      setLlmEnabled(configuration.enabled);
+      setLlmEndpoint(configuration.endpoint ?? "");
+      setLlmApiKey(configuration.apiKey ?? "");
+      setLlmModel(configuration.model ?? "");
+    }
+
+    void hydrateConfiguration();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    setSaveStatus("saving");
+
+    try {
+      const trimmedModel = llmModel.trim();
+      await saveLLMConfiguration({
+        enabled: llmEnabled,
+        endpoint: llmEndpoint.trim(),
+        apiKey: llmApiKey.trim(),
+        model: trimmedModel.length > 0 ? trimmedModel : undefined
+      });
+
+      setSaveStatus("saved");
+      setTimeout(() => setSaveStatus("idle"), 2000);
+    } catch (error) {
+      console.error("Failed to persist LLM configuration", error);
+      setSaveStatus("error");
+    }
+  }
 
   return (
     <section>
@@ -14,6 +76,71 @@ export function Settings(): JSX.Element {
         />
         Enable automatic bookmark synchronization
       </label>
+
+      <section aria-labelledby="llm-settings-heading">
+        <h2 id="llm-settings-heading">LLM Categorization</h2>
+        <p>
+          Configure credentials used by the background worker when requesting AI-assisted bookmark
+          categorization.
+        </p>
+        <form onSubmit={handleSubmit}>
+          <label>
+            <input
+              type="checkbox"
+              checked={llmEnabled}
+              onChange={(event) => setLlmEnabled(event.target.checked)}
+            />
+            Enable AI categorization
+          </label>
+
+          <label>
+            Endpoint
+            <input
+              type="url"
+              value={llmEndpoint}
+              onChange={(event) => setLlmEndpoint(event.target.value)}
+              placeholder="https://api.openai.com/v1/bookmarks"
+              required={llmEnabled}
+            />
+          </label>
+
+          <label>
+            API Key
+            <input
+              type="password"
+              value={llmApiKey}
+              onChange={(event) => setLlmApiKey(event.target.value)}
+              placeholder="sk-..."
+              required={llmEnabled}
+              autoComplete="off"
+            />
+          </label>
+
+          <label>
+            Model (optional)
+            <input
+              type="text"
+              value={llmModel}
+              onChange={(event) => setLlmModel(event.target.value)}
+              placeholder="gpt-4o-mini"
+            />
+          </label>
+
+          <button type="submit" disabled={saveStatus === "saving"}>
+            {saveStatus === "saving" ? "Saving..." : "Save LLM Settings"}
+          </button>
+
+          {saveStatus === "saved" && <p role="status">LLM settings saved.</p>}
+          {saveStatus === "error" && (
+            <p role="alert">Unable to save settings. Please check the extension console.</p>
+          )}
+        </form>
+        <p>
+          Settings are stored using the browser&apos;s extension storage under the key
+          <code>{LLM_CONFIGURATION_STORAGE_KEY}</code> and read by the background worker during
+          synchronization.
+        </p>
+      </section>
     </section>
   );
 }

--- a/packages/web-extension/src/types/node-test.d.ts
+++ b/packages/web-extension/src/types/node-test.d.ts
@@ -1,0 +1,16 @@
+declare module "node:test" {
+  export function describe(name: string, fn: () => void | Promise<void>): void;
+  export function it(name: string, fn: () => void | Promise<void>): void;
+  export function afterEach(fn: () => void | Promise<void>): void;
+}
+
+declare module "node:assert/strict" {
+  interface AssertModule {
+    strictEqual(actual: unknown, expected: unknown, message?: string): void;
+    deepStrictEqual(actual: unknown, expected: unknown, message?: string): void;
+    ok(value: unknown, message?: string): void;
+  }
+
+  const assert: AssertModule;
+  export default assert;
+}

--- a/packages/web-extension/src/types/webextension.d.ts
+++ b/packages/web-extension/src/types/webextension.d.ts
@@ -1,0 +1,18 @@
+interface BrowserStorageArea {
+  get(keys?: string | string[] | Record<string, unknown> | null): Promise<Record<string, unknown>>;
+  set(items: Record<string, unknown>): Promise<void>;
+}
+
+interface BrowserStorage {
+  local: BrowserStorageArea;
+}
+
+interface Browser {
+  storage: BrowserStorage;
+}
+
+declare const browser: Browser;
+
+declare const chrome: {
+  storage?: BrowserStorage;
+} | undefined;

--- a/packages/web-extension/tsconfig.json
+++ b/packages/web-extension/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "jsx": "react-jsx",
+    "lib": ["ES2021", "DOM"],
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- introduce an async LLM-powered bookmark categorizer that falls back to the heuristic when configuration is missing or requests fail
- persist API credentials through browser storage, expose them in the options UI, and request host permissions for the chosen endpoint
- convert the background sync to await the new service and add node-based unit tests for both the LLM categorizer and heuristic fallback

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d002d6e094832ab3ba3701df9104c2