### PR TITLE
Implement bookmark sync via WebExtension API

### DIFF
--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -5,7 +5,7 @@
   "type": "commonjs",
   "scripts": {
     "build": "tsc --project tsconfig.json",
-    "test": "npm run build --silent && node --test dist/domain/services/__tests__/*.test.js"
+    "test": "npm run build --silent && node --test dist/domain/services/__tests__/*.test.js dist/background/bookmark-sync/__tests__/*.test.js"
   },
   "devDependencies": {
     "typescript": "^5.4.0"

--- a/packages/web-extension/src/background/bookmark-sync/__tests__/bookmark-tree.test.ts
+++ b/packages/web-extension/src/background/bookmark-sync/__tests__/bookmark-tree.test.ts
@@ -1,0 +1,129 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { BookmarkTreeNode, flattenBookmarkTree } from "../bookmark-tree";
+
+describe("flattenBookmarkTree", () => {
+  it("flattens Chromium bookmark tree payloads", () => {
+    const firstTimestamp = 1716230400000;
+    const secondTimestamp = 1716316800000;
+
+    const chromiumTree: BookmarkTreeNode[] = [
+      {
+        id: "0",
+        title: "",
+        children: [
+          {
+            id: "1",
+            title: "Bookmarks bar",
+            children: [
+              {
+                id: "10",
+                title: "Example Domain",
+                url: "https://example.com",
+                dateAdded: firstTimestamp
+              }
+            ]
+          },
+          {
+            id: "2",
+            title: "Other bookmarks",
+            children: [
+              {
+                id: "20",
+                title: "MDN Web Docs",
+                url: "https://developer.mozilla.org",
+                dateAdded: secondTimestamp
+              }
+            ]
+          }
+        ]
+      }
+    ];
+
+    const bookmarks = flattenBookmarkTree(chromiumTree);
+
+    assert.deepStrictEqual(bookmarks, [
+      {
+        id: "10",
+        title: "Example Domain",
+        url: "https://example.com",
+        tags: [],
+        createdAt: new Date(firstTimestamp).toISOString()
+      },
+      {
+        id: "20",
+        title: "MDN Web Docs",
+        url: "https://developer.mozilla.org",
+        tags: [],
+        createdAt: new Date(secondTimestamp).toISOString()
+      }
+    ]);
+  });
+
+  it("normalizes Firefox bookmark tree payloads", () => {
+    const firstTimestamp = 1716403200000;
+    const secondTimestamp = 1716489600000;
+
+    const firefoxTree: BookmarkTreeNode[] = [
+      {
+        id: "root________",
+        title: "",
+        type: "folder",
+        children: [
+          {
+            id: "toolbar_____",
+            title: "Bookmarks Toolbar",
+            type: "folder",
+            children: [
+              {
+                id: "ff-1",
+                title: "MDN Web Docs",
+                url: "https://developer.mozilla.org",
+                type: "bookmark",
+                dateAdded: firstTimestamp,
+                tags: "reference,  web ",
+                metaInfo: { tags: "reference" }
+              }
+            ]
+          },
+          {
+            id: "menu________",
+            title: "Bookmarks Menu",
+            type: "folder",
+            children: [
+              {
+                id: "ff-2",
+                title: "Example Domain",
+                url: "https://example.com",
+                type: "bookmark",
+                dateAdded: secondTimestamp,
+                tags: " ",
+                metaInfo: { tag: "general, samples" }
+              }
+            ]
+          }
+        ]
+      }
+    ];
+
+    const bookmarks = flattenBookmarkTree(firefoxTree);
+
+    assert.deepStrictEqual(bookmarks, [
+      {
+        id: "ff-1",
+        title: "MDN Web Docs",
+        url: "https://developer.mozilla.org",
+        tags: ["reference", "web"],
+        createdAt: new Date(firstTimestamp).toISOString()
+      },
+      {
+        id: "ff-2",
+        title: "Example Domain",
+        url: "https://example.com",
+        tags: ["general", "samples"],
+        createdAt: new Date(secondTimestamp).toISOString()
+      }
+    ]);
+  });
+});

--- a/packages/web-extension/src/background/bookmark-sync/bookmark-tree.ts
+++ b/packages/web-extension/src/background/bookmark-sync/bookmark-tree.ts
@@ -1,0 +1,75 @@
+import { Bookmark } from "../../domain/models/bookmark";
+
+export interface BookmarkTreeNode {
+  id: string;
+  title?: string;
+  url?: string;
+  dateAdded?: number;
+  children?: BookmarkTreeNode[];
+  tags?: string | string[];
+  metaInfo?: Record<string, string | undefined>;
+  [key: string]: unknown;
+}
+
+export function flattenBookmarkTree(tree: BookmarkTreeNode[]): Bookmark[] {
+  const bookmarks: Bookmark[] = [];
+
+  const visit = (node: BookmarkTreeNode): void => {
+    if (typeof node.url === "string") {
+      bookmarks.push({
+        id: node.id,
+        title: node.title ?? "",
+        url: node.url,
+        tags: collectTags(node),
+        createdAt: toIsoDate(node.dateAdded)
+      });
+    }
+
+    if (Array.isArray(node.children)) {
+      for (const child of node.children) {
+        visit(child);
+      }
+    }
+  };
+
+  for (const node of tree) {
+    visit(node);
+  }
+
+  return bookmarks;
+}
+
+function collectTags(node: BookmarkTreeNode): string[] {
+  const tags: string[] = [];
+
+  const append = (value?: string | string[]): void => {
+    if (!value) {
+      return;
+    }
+
+    const values = Array.isArray(value) ? value : value.split(",");
+
+    for (const entry of values) {
+      const trimmed = entry.trim();
+      if (trimmed.length === 0 || tags.includes(trimmed)) {
+        continue;
+      }
+
+      tags.push(trimmed);
+    }
+  };
+
+  append(node.tags);
+
+  if (node.metaInfo) {
+    append(node.metaInfo.tags);
+    append(node.metaInfo.tag);
+  }
+
+  return tags;
+}
+
+function toIsoDate(dateAdded?: number): string {
+  const timestamp = typeof dateAdded === "number" ? dateAdded : 0;
+  return new Date(timestamp).toISOString();
+}

--- a/packages/web-extension/src/background/bookmark-sync/chromium-provider.ts
+++ b/packages/web-extension/src/background/bookmark-sync/chromium-provider.ts
@@ -1,6 +1,56 @@
 import { Bookmark } from "../../domain/models/bookmark";
+import { BookmarkTreeNode, flattenBookmarkTree } from "./bookmark-tree";
+
+type BrowserNamespace = {
+  bookmarks?: {
+    getTree: () => Promise<BookmarkTreeNode[]>;
+  };
+};
+
+type ChromeNamespace = {
+  bookmarks?: {
+    getTree(callback: (nodes: BookmarkTreeNode[]) => void): void;
+  };
+  runtime?: {
+    lastError?: { message?: string };
+  };
+};
+
+type GlobalWithWebExtensionAPIs = typeof globalThis & {
+  browser?: BrowserNamespace;
+  chrome?: ChromeNamespace;
+};
 
 export async function fetchChromiumBookmarks(): Promise<Bookmark[]> {
-  // Placeholder implementation to describe the expected interface.
-  return Promise.resolve([]);
+  const globalObject = globalThis as GlobalWithWebExtensionAPIs;
+
+  if (globalObject.browser?.bookmarks?.getTree) {
+    const tree = await globalObject.browser.bookmarks.getTree();
+    return flattenBookmarkTree(tree);
+  }
+
+  const chromeNamespace = globalObject.chrome;
+  const chromeBookmarks = chromeNamespace?.bookmarks;
+
+  if (chromeBookmarks?.getTree) {
+    const tree = await new Promise<BookmarkTreeNode[]>((resolve, reject) => {
+      try {
+        chromeBookmarks.getTree((nodes) => {
+          const errorMessage = chromeNamespace?.runtime?.lastError?.message;
+          if (errorMessage) {
+            reject(new Error(errorMessage));
+            return;
+          }
+
+          resolve(nodes);
+        });
+      } catch (error) {
+        reject(error);
+      }
+    });
+
+    return flattenBookmarkTree(tree);
+  }
+
+  return [];
 }

--- a/packages/web-extension/src/background/bookmark-sync/firefox-provider.ts
+++ b/packages/web-extension/src/background/bookmark-sync/firefox-provider.ts
@@ -1,6 +1,56 @@
 import { Bookmark } from "../../domain/models/bookmark";
+import { BookmarkTreeNode, flattenBookmarkTree } from "./bookmark-tree";
+
+type BrowserNamespace = {
+  bookmarks?: {
+    getTree: () => Promise<BookmarkTreeNode[]>;
+  };
+};
+
+type ChromeNamespace = {
+  bookmarks?: {
+    getTree(callback: (nodes: BookmarkTreeNode[]) => void): void;
+  };
+  runtime?: {
+    lastError?: { message?: string };
+  };
+};
+
+type GlobalWithWebExtensionAPIs = typeof globalThis & {
+  browser?: BrowserNamespace;
+  chrome?: ChromeNamespace;
+};
 
 export async function fetchFirefoxBookmarks(): Promise<Bookmark[]> {
-  // Placeholder implementation to describe the expected interface.
-  return Promise.resolve([]);
+  const globalObject = globalThis as GlobalWithWebExtensionAPIs;
+
+  if (globalObject.browser?.bookmarks?.getTree) {
+    const tree = await globalObject.browser.bookmarks.getTree();
+    return flattenBookmarkTree(tree);
+  }
+
+  const chromeNamespace = globalObject.chrome;
+  const chromeBookmarks = chromeNamespace?.bookmarks;
+
+  if (chromeBookmarks?.getTree) {
+    const tree = await new Promise<BookmarkTreeNode[]>((resolve, reject) => {
+      try {
+        chromeBookmarks.getTree((nodes) => {
+          const errorMessage = chromeNamespace?.runtime?.lastError?.message;
+          if (errorMessage) {
+            reject(new Error(errorMessage));
+            return;
+          }
+
+          resolve(nodes);
+        });
+      } catch (error) {
+        reject(error);
+      }
+    });
+
+    return flattenBookmarkTree(tree);
+  }
+
+  return [];
 }


### PR DESCRIPTION
## Summary
- add a helper to flatten WebExtension bookmark trees into Bookmark models with normalized metadata
- update Chromium and Firefox providers to request the browser.bookmarks tree (with a chrome fallback) and reuse the helper
- expand automated coverage for bookmark sync by testing Chromium and Firefox payload shapes and wiring the tests into the npm script

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d00e696e40832a914a745dda8c3b99