### PR TITLE
Register background synchronization hooks

### DIFF
--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -5,7 +5,7 @@
   "type": "commonjs",
   "scripts": {
     "build": "tsc --project tsconfig.json",
-    "test": "npm run build --silent && node --test dist/domain/services/__tests__/*.test.js dist/background/bookmark-sync/__tests__/*.test.js"
+    "test": "npm run build --silent && node --test dist/domain/services/__tests__/*.test.js dist/background/bookmark-sync/__tests__/*.test.js dist/background/__tests__/*.test.js"
   },
   "devDependencies": {
     "typescript": "^5.4.0"

--- a/packages/web-extension/src/background/__tests__/index.test.ts
+++ b/packages/web-extension/src/background/__tests__/index.test.ts
@@ -1,0 +1,125 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  BOOKMARK_SYNC_ALARM_NAME,
+  BOOKMARK_SYNC_ALARM_PERIOD_MINUTES,
+  registerBackgroundListeners
+} from "../index";
+
+describe("registerBackgroundListeners", () => {
+  it("invokes the synchronizer when runtime events fire", async () => {
+    let installedListener: ((...args: unknown[]) => void) | undefined;
+    let startupListener: ((...args: unknown[]) => void) | undefined;
+
+    const runtime = {
+      onInstalled: {
+        addListener: (listener: (...args: unknown[]) => void) => {
+          installedListener = listener;
+        }
+      },
+      onStartup: {
+        addListener: (listener: (...args: unknown[]) => void) => {
+          startupListener = listener;
+        }
+      }
+    };
+
+    let callCount = 0;
+    const synchronizer = () => {
+      callCount += 1;
+      return Promise.resolve();
+    };
+
+    registerBackgroundListeners({ runtime }, synchronizer);
+
+    assert.ok(installedListener);
+    assert.ok(startupListener);
+
+    installedListener?.();
+    await Promise.resolve();
+    assert.strictEqual(callCount, 1);
+
+    startupListener?.();
+    await Promise.resolve();
+    assert.strictEqual(callCount, 2);
+  });
+
+  it("schedules and reacts to periodic alarms", async () => {
+    let alarmListener: ((alarm?: { name?: string }) => void) | undefined;
+    let createdAlarmName: string | undefined;
+    let createdAlarmPeriod: number | undefined;
+
+    const alarms = {
+      create: (name: string, info: { periodInMinutes: number }) => {
+        createdAlarmName = name;
+        createdAlarmPeriod = info.periodInMinutes;
+      },
+      onAlarm: {
+        addListener: (listener: (alarm?: { name?: string }) => void) => {
+          alarmListener = listener;
+        }
+      }
+    };
+
+    let callCount = 0;
+    const synchronizer = () => {
+      callCount += 1;
+      return Promise.resolve();
+    };
+
+    registerBackgroundListeners({ alarms }, synchronizer);
+
+    assert.strictEqual(createdAlarmName, BOOKMARK_SYNC_ALARM_NAME);
+    assert.strictEqual(
+      createdAlarmPeriod,
+      BOOKMARK_SYNC_ALARM_PERIOD_MINUTES
+    );
+    assert.ok(alarmListener);
+
+    alarmListener?.({ name: BOOKMARK_SYNC_ALARM_NAME });
+    await Promise.resolve();
+    assert.strictEqual(callCount, 1);
+
+    alarmListener?.({ name: "another-alarm" });
+    await Promise.resolve();
+    assert.strictEqual(callCount, 1);
+
+    alarmListener?.({});
+    await Promise.resolve();
+    assert.strictEqual(callCount, 2);
+  });
+
+  it("logs synchronization failures", async () => {
+    let installedListener: ((...args: unknown[]) => void) | undefined;
+    const runtime = {
+      onInstalled: {
+        addListener: (listener: (...args: unknown[]) => void) => {
+          installedListener = listener;
+        }
+      }
+    };
+
+    const error = new Error("boom");
+    const synchronizer = () => Promise.reject(error);
+
+    const originalConsoleError = console.error;
+    const calls: unknown[][] = [];
+    console.error = (...args: unknown[]) => {
+      calls.push(args);
+    };
+
+    try {
+      registerBackgroundListeners({ runtime }, synchronizer);
+
+      assert.ok(installedListener);
+      installedListener?.();
+      await Promise.resolve();
+
+      assert.strictEqual(calls.length, 1);
+      assert.strictEqual(calls[0][0], "Failed to synchronize bookmarks");
+      assert.strictEqual(calls[0][1], error);
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+});

--- a/packages/web-extension/src/background/index.ts
+++ b/packages/web-extension/src/background/index.ts
@@ -4,6 +4,32 @@ import { searchBookmarks } from "../domain/services/search";
 import { fetchChromiumBookmarks } from "./bookmark-sync/chromium-provider";
 import { fetchFirefoxBookmarks } from "./bookmark-sync/firefox-provider";
 
+export const BOOKMARK_SYNC_ALARM_NAME = "capybara::bookmark-sync";
+export const BOOKMARK_SYNC_ALARM_PERIOD_MINUTES = 30;
+
+type RuntimeEvent = {
+  addListener: (listener: (...args: unknown[]) => void) => void;
+};
+
+type RuntimeAPI = {
+  onInstalled?: RuntimeEvent;
+  onStartup?: RuntimeEvent;
+};
+
+type AlarmListener = (alarm?: { name?: string }) => void;
+
+type AlarmsAPI = {
+  create?: (name: string, info: { periodInMinutes: number }) => void;
+  onAlarm?: {
+    addListener: (listener: AlarmListener) => void;
+  };
+};
+
+export type BackgroundExtensionAPI = {
+  runtime?: RuntimeAPI;
+  alarms?: AlarmsAPI;
+};
+
 export async function synchronizeBookmarks(): Promise<void> {
   const [chromiumBookmarks, firefoxBookmarks] = await Promise.all([
     fetchChromiumBookmarks(),
@@ -14,3 +40,83 @@ export async function synchronizeBookmarks(): Promise<void> {
   const categorized = await categorizeBookmarksWithLLM(merged);
   searchBookmarks.index(categorized);
 }
+
+function createSynchronizationHandler(
+  synchronizer: () => Promise<void>
+): () => void {
+  return () => {
+    synchronizer().catch((error: unknown) => {
+      console.error("Failed to synchronize bookmarks", error);
+    });
+  };
+}
+
+function attachRuntimeListener(
+  event: RuntimeEvent | undefined,
+  handler: () => void
+): void {
+  if (!event?.addListener) {
+    return;
+  }
+
+  event.addListener(() => {
+    handler();
+  });
+}
+
+function registerAlarmListener(
+  alarms: AlarmsAPI | undefined,
+  handler: () => void
+): void {
+  if (!alarms) {
+    return;
+  }
+
+  const { onAlarm, create } = alarms;
+
+  if (onAlarm?.addListener) {
+    onAlarm.addListener((alarm) => {
+      if (!alarm?.name || alarm.name === BOOKMARK_SYNC_ALARM_NAME) {
+        handler();
+      }
+    });
+  }
+
+  if (create) {
+    try {
+      create(BOOKMARK_SYNC_ALARM_NAME, {
+        periodInMinutes: BOOKMARK_SYNC_ALARM_PERIOD_MINUTES
+      });
+    } catch (error) {
+      console.error(
+        "Failed to schedule bookmark synchronization alarm",
+        error
+      );
+    }
+  }
+}
+
+export function registerBackgroundListeners(
+  extensionAPI: BackgroundExtensionAPI | undefined,
+  synchronizer: () => Promise<void> = synchronizeBookmarks
+): void {
+  if (!extensionAPI) {
+    return;
+  }
+
+  const handler = createSynchronizationHandler(synchronizer);
+
+  attachRuntimeListener(extensionAPI.runtime?.onInstalled, handler);
+  attachRuntimeListener(extensionAPI.runtime?.onStartup, handler);
+  registerAlarmListener(extensionAPI.alarms, handler);
+}
+
+const detectedExtensionAPI: BackgroundExtensionAPI | undefined =
+  (typeof browser !== "undefined"
+    ? (browser as unknown as BackgroundExtensionAPI)
+    : undefined) ??
+  (typeof chrome !== "undefined"
+    ? (chrome as unknown as BackgroundExtensionAPI)
+    : undefined);
+
+registerBackgroundListeners(detectedExtensionAPI);

--- a/packages/web-extension/src/types/webextension.d.ts
+++ b/packages/web-extension/src/types/webextension.d.ts
@@ -7,12 +7,36 @@ interface BrowserStorage {
   local: BrowserStorageArea;
 }
 
+interface BrowserRuntimeEvent {
+  addListener(callback: (...args: unknown[]) => void): void;
+}
+
+interface BrowserRuntime {
+  onInstalled?: BrowserRuntimeEvent;
+  onStartup?: BrowserRuntimeEvent;
+}
+
+interface BrowserAlarm {
+  name?: string;
+}
+
+interface BrowserAlarms {
+  create?(name: string, info: { periodInMinutes: number }): void;
+  onAlarm?: {
+    addListener(callback: (alarm: BrowserAlarm) => void): void;
+  };
+}
+
 interface Browser {
   storage: BrowserStorage;
+  runtime?: BrowserRuntime;
+  alarms?: BrowserAlarms;
 }
 
 declare const browser: Browser;
 
 declare const chrome: {
   storage?: BrowserStorage;
+  runtime?: BrowserRuntime;
+  alarms?: BrowserAlarms;
 } | undefined;


### PR DESCRIPTION
## Summary
- register background background listeners for runtime lifecycle events with error logging and periodic alarm scheduling
- extend the WebExtension type declarations to cover runtime and alarm APIs
- add mocked integration tests for the background listeners and wire them into the package test command

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0105602d4832ab0d5c1979efaea34