### PR TITLE
Include TSX sources in web extension build

### DIFF
--- a/.github/workflows/web-extension.yml
+++ b/.github/workflows/web-extension.yml
@@ -1,0 +1,26 @@
+name: Web Extension Build
+
+on:
+  push:
+    paths:
+      - 'packages/web-extension/**'
+      - '.github/workflows/web-extension.yml'
+  pull_request:
+    paths:
+      - 'packages/web-extension/**'
+      - '.github/workflows/web-extension.yml'
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/web-extension
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npm run build
+      - run: npm run verify:jsx

--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -5,6 +5,7 @@
   "type": "commonjs",
   "scripts": {
     "build": "tsc --project tsconfig.json",
+    "verify:jsx": "node ./scripts/verify-jsx-build.mjs",
     "test": "npm run build --silent && node --test dist/domain/services/__tests__/*.test.js dist/background/bookmark-sync/__tests__/*.test.js dist/background/__tests__/*.test.js"
   },
   "devDependencies": {

--- a/packages/web-extension/scripts/verify-jsx-build.mjs
+++ b/packages/web-extension/scripts/verify-jsx-build.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+import { access, readdir } from "node:fs/promises";
+import path from "node:path";
+
+const SRC_DIR = path.resolve("src");
+const DIST_DIR = path.resolve("dist");
+
+async function collectJsxSources(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectJsxSources(entryPath)));
+    } else if (entry.name.endsWith(".tsx") || entry.name.endsWith(".jsx")) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+const sourceFiles = await collectJsxSources(SRC_DIR);
+
+if (sourceFiles.length === 0) {
+  console.log("No TSX/JSX sources detected. Nothing to verify.");
+  process.exit(0);
+}
+
+const missingOutputs = [];
+
+for (const sourceFile of sourceFiles) {
+  const relativePath = path.relative(SRC_DIR, sourceFile);
+  const { dir, name } = path.parse(relativePath);
+  const outputPath = path.join(DIST_DIR, dir, `${name}.js`);
+
+  try {
+    await access(outputPath);
+  } catch (error) {
+    missingOutputs.push(path.relative(process.cwd(), outputPath));
+  }
+}
+
+if (missingOutputs.length > 0) {
+  console.error("Missing compiled outputs for the following TSX/JSX sources:");
+  for (const missing of missingOutputs) {
+    console.error(` - ${missing}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `Verified compiled outputs for ${sourceFiles.length} TSX/JSX source ${sourceFiles.length === 1 ? "file" : "files"}.`
+);

--- a/packages/web-extension/src/types/react-shim.d.ts
+++ b/packages/web-extension/src/types/react-shim.d.ts
@@ -1,0 +1,73 @@
+type ReactEventTarget<T> = {
+  target: T & EventTarget;
+};
+
+declare module "react" {
+  export type FormEvent<T = Element> = ReactEventTarget<T> & {
+    preventDefault(): void;
+  };
+
+  export type ChangeEvent<T = Element> = ReactEventTarget<T>;
+
+  export function useState<S>(
+    initialState: S | (() => S)
+  ): [S, (value: S | ((prevState: S) => S)) => void];
+
+  export function useEffect(effect: () => void | (() => void), deps?: ReadonlyArray<unknown>): void;
+
+  export function useMemo<T>(factory: () => T, deps: ReadonlyArray<unknown> | undefined): T;
+}
+
+declare namespace JSX {
+  type Element = any;
+  interface ElementClass {}
+  interface ElementChildrenAttribute {
+    children: {};
+  }
+
+  type BaseProps = {
+    children?: any;
+    [key: string]: any;
+  };
+
+  interface IntrinsicElements {
+    main: BaseProps;
+    header: BaseProps;
+    h1: BaseProps;
+    h2: BaseProps;
+    section: BaseProps;
+    label: BaseProps;
+    form: BaseProps & {
+      onSubmit?: (event: import("react").FormEvent<HTMLFormElement>) => void;
+    };
+    p: BaseProps;
+    code: BaseProps;
+    button: BaseProps & {
+      type?: string;
+      disabled?: boolean;
+    };
+    input: BaseProps & {
+      type?: string;
+      value?: string;
+      checked?: boolean;
+      placeholder?: string;
+      autoComplete?: string;
+      required?: boolean;
+      onChange?: (event: import("react").ChangeEvent<HTMLInputElement>) => void;
+    };
+    ul: BaseProps;
+    li: BaseProps;
+    a: BaseProps & {
+      href?: string;
+      target?: string;
+      rel?: string;
+    };
+    span: BaseProps;
+  }
+}
+
+declare module "react/jsx-runtime" {
+  export const jsx: any;
+  export const jsxs: any;
+  export const Fragment: any;
+}

--- a/packages/web-extension/tsconfig.json
+++ b/packages/web-extension/tsconfig.json
@@ -14,6 +14,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*.ts", "src/**/*.d.ts"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.jsx", "src/**/*.d.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- include TSX/JSX sources in the web extension TypeScript project
- add lightweight React type shims so the extension TSX can compile without external packages
- add a verification script and CI workflow to ensure TSX files emit JavaScript outputs

## Testing
- npm run build
- npm run verify:jsx

------
https://chatgpt.com/codex/tasks/task_e_68d0196b7b88832a9dbbd19bed733e88