### PR TITLE
Add popup React entrypoint

### DIFF
--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -6,9 +6,15 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "verify:jsx": "node ./scripts/verify-jsx-build.mjs",
-    "test": "npm run build --silent && node --test dist/domain/services/__tests__/*.test.js dist/background/bookmark-sync/__tests__/*.test.js dist/background/__tests__/*.test.js"
+    "test": "npm run build --silent && node --test dist/domain/services/__tests__/*.test.js dist/background/bookmark-sync/__tests__/*.test.js dist/background/__tests__/*.test.js dist/popup/__tests__/*.test.js"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
     "typescript": "^5.4.0"
   }
 }

--- a/packages/web-extension/src/popup/__tests__/index.test.ts
+++ b/packages/web-extension/src/popup/__tests__/index.test.ts
@@ -1,0 +1,68 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import ReactDOM from "react-dom";
+
+describe("popup entrypoint", () => {
+  it("renders the App component into the root element", async () => {
+    const { App } = await import("../App");
+
+    const rootElement = {} as unknown as HTMLElement;
+    const requestedIds: string[] = [];
+
+    const fakeDocument = {
+      getElementById: (id: string) => {
+        requestedIds.push(id);
+        if (id === "root") {
+          return rootElement;
+        }
+        return null;
+      }
+    };
+
+    const globalScope = globalThis as { document?: Document };
+    const hadDocument = Object.prototype.hasOwnProperty.call(
+      globalScope,
+      "document"
+    );
+    const previousDocument = globalScope.document;
+    globalScope.document = fakeDocument as unknown as Document;
+
+    const renderCalls: Array<[unknown, unknown, unknown?]> = [];
+    const originalRender = ReactDOM.render;
+
+    (ReactDOM as unknown as {
+      render: typeof originalRender;
+    }).render = ((
+      element: unknown,
+      container: Element | DocumentFragment | null,
+      callback?: () => void
+    ) => {
+      renderCalls.push([element, container, callback]);
+      if (callback) {
+        callback();
+      }
+      return null as never;
+    }) as typeof originalRender;
+
+    try {
+      await import("../index");
+
+      assert.deepStrictEqual(requestedIds, ["root"]);
+      assert.strictEqual(renderCalls.length, 1);
+
+      const [element, container] = renderCalls[0];
+      assert.strictEqual(container, rootElement);
+      assert.ok(element && typeof element === "object");
+      assert.strictEqual((element as { type?: unknown }).type, App);
+    } finally {
+      (ReactDOM as unknown as { render: typeof originalRender }).render =
+        originalRender;
+
+      if (hadDocument) {
+        globalScope.document = previousDocument;
+      } else {
+        delete globalScope.document;
+      }
+    }
+  });
+});

--- a/packages/web-extension/src/popup/index.tsx
+++ b/packages/web-extension/src/popup/index.tsx
@@ -1,0 +1,10 @@
+import ReactDOM from "react-dom";
+import { App } from "./App";
+
+const rootElement = document.getElementById("root");
+
+if (!rootElement) {
+  throw new Error("Failed to locate the popup root element.");
+}
+
+ReactDOM.render(<App />, rootElement);


### PR DESCRIPTION
## Summary
- add React runtime and type dependencies to the web-extension package and include the popup test suite in the npm test script
- add a popup entrypoint that mounts the App component with ReactDOM
- cover the entrypoint with a unit test that asserts the root element is resolved and App is rendered

## Testing
- npm run test --prefix packages/web-extension *(fails: TypeScript cannot resolve `react-dom` because the npm registry is inaccessible in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d01bf45bec832ab8fd2b028328d378