### PR TITLE
feat: add extension storage helper

### DIFF
--- a/packages/web-extension/src/domain/services/__tests__/extension-storage.test.ts
+++ b/packages/web-extension/src/domain/services/__tests__/extension-storage.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { getItem, setItem } from "../extension-storage";
+import { loadLLMConfiguration, saveLLMConfiguration } from "../llm-settings";
+import { LLM_CONFIGURATION_STORAGE_KEY, type LLMConfiguration } from "../../models/llm-configuration";
+
+type MockStorageArea = {
+  get: (keys: string | string[] | Record<string, unknown>) => Promise<Record<string, unknown>>;
+  set: (items: Record<string, unknown>) => Promise<void>;
+};
+
+type ExtensionNamespace = {
+  storage: {
+    local: MockStorageArea;
+  };
+};
+
+type ExtensionTestGlobals = typeof globalThis & {
+  browser?: ExtensionNamespace;
+  chrome?: ExtensionNamespace;
+};
+
+const extensionGlobals = globalThis as ExtensionTestGlobals;
+
+afterEach(() => {
+  delete extensionGlobals.browser;
+  delete extensionGlobals.chrome;
+});
+
+describe("extension storage helpers", () => {
+  it("uses chrome storage when the browser namespace is unavailable", async () => {
+    const storedConfiguration: LLMConfiguration = {
+      enabled: true,
+      endpoint: "https://api.example.com/v1/llm",
+      apiKey: "token",
+      model: "model-v1"
+    };
+
+    const storageState: Record<string, unknown> = {
+      [LLM_CONFIGURATION_STORAGE_KEY]: storedConfiguration
+    };
+
+    let getKey: string | string[] | Record<string, unknown> | undefined;
+
+    extensionGlobals.chrome = {
+      storage: {
+        local: {
+          async get(key) {
+            getKey = key;
+            return { ...storageState };
+          },
+          async set(items) {
+            Object.assign(storageState, items);
+          }
+        }
+      }
+    };
+
+    const retrieved = await getItem(LLM_CONFIGURATION_STORAGE_KEY);
+
+    assert.deepStrictEqual(retrieved, storedConfiguration);
+    assert.strictEqual(getKey, LLM_CONFIGURATION_STORAGE_KEY);
+
+    const updatedConfiguration: LLMConfiguration = {
+      ...storedConfiguration,
+      enabled: false
+    };
+
+    await setItem(LLM_CONFIGURATION_STORAGE_KEY, updatedConfiguration);
+
+    assert.deepStrictEqual(storageState[LLM_CONFIGURATION_STORAGE_KEY], updatedConfiguration);
+  });
+
+  it("normalizes stored configuration values when loading and persists saves", async () => {
+    const storageState: Record<string, unknown> = {
+      [LLM_CONFIGURATION_STORAGE_KEY]: {
+        enabled: 0,
+        endpoint: 123,
+        apiKey: null,
+        model: 99
+      }
+    };
+
+    const setCalls: Record<string, unknown>[] = [];
+
+    extensionGlobals.browser = {
+      storage: {
+        local: {
+          async get(key) {
+            assert.strictEqual(key, LLM_CONFIGURATION_STORAGE_KEY);
+            return { ...storageState };
+          },
+          async set(items) {
+            setCalls.push(items);
+            Object.assign(storageState, items);
+          }
+        }
+      }
+    };
+
+    const loaded = await loadLLMConfiguration();
+
+    assert.deepStrictEqual(loaded, {
+      enabled: false,
+      endpoint: "",
+      apiKey: "",
+      model: undefined
+    });
+
+    const configurationToSave: LLMConfiguration = {
+      enabled: true,
+      endpoint: "https://api.example.com/v1/llm",
+      apiKey: "token",
+      model: "model-v2"
+    };
+
+    await saveLLMConfiguration(configurationToSave);
+
+    assert.strictEqual(setCalls.length, 1);
+    assert.deepStrictEqual(setCalls[0], {
+      [LLM_CONFIGURATION_STORAGE_KEY]: configurationToSave
+    });
+    assert.deepStrictEqual(storageState[LLM_CONFIGURATION_STORAGE_KEY], configurationToSave);
+  });
+});

--- a/packages/web-extension/src/domain/services/extension-storage.ts
+++ b/packages/web-extension/src/domain/services/extension-storage.ts
@@ -1,0 +1,47 @@
+import { LLM_CONFIGURATION_STORAGE_KEY, type LLMConfiguration } from "../models/llm-configuration";
+
+type StorageKeyMap = {
+  [LLM_CONFIGURATION_STORAGE_KEY]: LLMConfiguration;
+};
+
+type StorageKey = keyof StorageKeyMap & string;
+
+type StorageValue<K extends StorageKey> = StorageKeyMap[K];
+
+type StorageArea = {
+  get: (keys: string | string[] | Record<string, unknown>) => Promise<Record<string, unknown>>;
+  set: (items: Record<string, unknown>) => Promise<void>;
+};
+
+type ExtensionStorageNamespace = {
+  local: StorageArea;
+};
+
+type ExtensionGlobals = typeof globalThis & {
+  browser?: { storage?: ExtensionStorageNamespace };
+  chrome?: { storage?: ExtensionStorageNamespace };
+};
+
+function resolveStorageArea(): StorageArea {
+  const globals = globalThis as ExtensionGlobals;
+  const namespace = globals.browser?.storage ?? globals.chrome?.storage;
+
+  if (!namespace?.local) {
+    throw new Error("Extension storage is unavailable");
+  }
+
+  return namespace.local;
+}
+
+export async function getItem<K extends StorageKey>(key: K): Promise<StorageValue<K> | null> {
+  const storage = resolveStorageArea();
+  const result = await storage.get(key);
+  const record = (result ?? {}) as Record<string, unknown>;
+  const value = (record[key] ?? null) as StorageValue<K> | null;
+  return value;
+}
+
+export async function setItem<K extends StorageKey>(key: K, value: StorageValue<K>): Promise<void> {
+  const storage = resolveStorageArea();
+  await storage.set({ [key]: value });
+}

--- a/packages/web-extension/src/domain/services/llm-settings.ts
+++ b/packages/web-extension/src/domain/services/llm-settings.ts
@@ -1,4 +1,5 @@
 import { LLM_CONFIGURATION_STORAGE_KEY, type LLMConfiguration } from "../models/llm-configuration";
+import { getItem, setItem } from "./extension-storage";
 
 function normalizeConfiguration(raw: unknown): LLMConfiguration | null {
   if (!raw || typeof raw !== "object") {
@@ -16,12 +17,10 @@ function normalizeConfiguration(raw: unknown): LLMConfiguration | null {
 }
 
 export async function loadLLMConfiguration(): Promise<LLMConfiguration | null> {
-  const stored = await browser.storage.local.get(LLM_CONFIGURATION_STORAGE_KEY);
-  return normalizeConfiguration(stored[LLM_CONFIGURATION_STORAGE_KEY]);
+  const stored = await getItem(LLM_CONFIGURATION_STORAGE_KEY);
+  return normalizeConfiguration(stored);
 }
 
 export async function saveLLMConfiguration(configuration: LLMConfiguration): Promise<void> {
-  await browser.storage.local.set({
-    [LLM_CONFIGURATION_STORAGE_KEY]: configuration
-  });
+  await setItem(LLM_CONFIGURATION_STORAGE_KEY, configuration);
 }

--- a/packages/web-extension/src/types/react-dom-shim.d.ts
+++ b/packages/web-extension/src/types/react-dom-shim.d.ts
@@ -1,0 +1,13 @@
+declare module "react-dom" {
+  export function render(
+    element: unknown,
+    container: Element | DocumentFragment | null,
+    callback?: () => void
+  ): unknown;
+
+  const ReactDOM: {
+    render: typeof render;
+  };
+
+  export default ReactDOM;
+}


### PR DESCRIPTION
## Summary
- add an extension storage helper that selects the browser or chrome namespace and exposes typed item helpers
- switch the LLM settings service to use the shared storage helper and keep existing normalization
- cover storage helper behaviour and persisted LLM configuration normalization in unit tests, adding a react-dom type shim for builds

## Testing
- `npm run test` *(fails: runtime cannot resolve the react-dom package in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d025a7a75c832aaad6209351307115