### PR TITLE
Persist bookmarks snapshot and hydrate search index

### DIFF
--- a/packages/web-extension/src/background/__tests__/index.test.ts
+++ b/packages/web-extension/src/background/__tests__/index.test.ts
@@ -1,10 +1,59 @@
-import { describe, it } from "node:test";
+import { afterEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
   BOOKMARK_SYNC_ALARM_NAME,
   BOOKMARK_SYNC_ALARM_PERIOD_MINUTES,
-  registerBackgroundListeners
+  bootstrapBackground,
+  registerBackgroundListeners,
+  synchronizeBookmarks
 } from "../index";
+import { searchBookmarks } from "../../domain/services/search";
+import type { Bookmark } from "../../domain/models/bookmark";
+import type { CategorizedBookmark } from "../../domain/models/categorized-bookmark";
+
+const chromiumProvider: any = require("../bookmark-sync/chromium-provider");
+const firefoxProvider: any = require("../bookmark-sync/firefox-provider");
+const mergerModule: any = require("../../domain/services/merger");
+const llmCategorizerModule: any = require("../../domain/services/llm-categorizer");
+
+function stubSynchronizationPipeline(options: {
+  chromium: Bookmark[];
+  firefox: Bookmark[];
+  merged: Bookmark[];
+  categorized: CategorizedBookmark[];
+}): () => void {
+  const originalChromium = chromiumProvider.fetchChromiumBookmarks;
+  const originalFirefox = firefoxProvider.fetchFirefoxBookmarks;
+  const originalMerge = mergerModule.mergeBookmarks;
+  const originalCategorize = llmCategorizerModule.categorizeBookmarksWithLLM;
+
+  chromiumProvider.fetchChromiumBookmarks = async () => options.chromium;
+  firefoxProvider.fetchFirefoxBookmarks = async () => options.firefox;
+  mergerModule.mergeBookmarks = () => options.merged;
+  llmCategorizerModule.categorizeBookmarksWithLLM = async () =>
+    options.categorized;
+
+  return () => {
+    chromiumProvider.fetchChromiumBookmarks = originalChromium;
+    firefoxProvider.fetchFirefoxBookmarks = originalFirefox;
+    mergerModule.mergeBookmarks = originalMerge;
+    llmCategorizerModule.categorizeBookmarksWithLLM = originalCategorize;
+  };
+}
+
+function createDeferred<T>() {
+  let resolve: (value: T | PromiseLike<T>) => void;
+  let reject: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve: resolve!, reject: reject! };
+}
+
+afterEach(() => {
+  searchBookmarks.index([], []);
+});
 
 describe("registerBackgroundListeners", () => {
   it("invokes the synchronizer when runtime events fire", async () => {
@@ -120,6 +169,199 @@ describe("registerBackgroundListeners", () => {
       assert.strictEqual(calls[0][1], error);
     } finally {
       console.error = originalConsoleError;
+    }
+  });
+});
+
+describe("synchronizeBookmarks", () => {
+  it("indexes bookmarks and persists the snapshot", async () => {
+    const chromium: Bookmark[] = [
+      {
+        id: "c-1",
+        title: "Chromium",
+        url: "https://chromium.example",
+        tags: ["chromium"],
+        createdAt: "2024-01-01T00:00:00.000Z"
+      }
+    ];
+
+    const firefox: Bookmark[] = [
+      {
+        id: "f-1",
+        title: "Firefox",
+        url: "https://firefox.example",
+        tags: ["firefox"],
+        createdAt: "2024-01-02T00:00:00.000Z"
+      }
+    ];
+
+    const merged: Bookmark[] = [...chromium, ...firefox];
+    const categorized: CategorizedBookmark[] = [
+      {
+        ...merged[0],
+        category: "browsers"
+      },
+      {
+        ...merged[1],
+        category: "mozilla"
+      }
+    ];
+
+    const restorePipeline = stubSynchronizationPipeline({
+      chromium,
+      firefox,
+      merged,
+      categorized
+    });
+
+    const indexCalls: Array<[CategorizedBookmark[], Bookmark[]]> = [];
+    const originalIndex = searchBookmarks.index;
+    searchBookmarks.index = ((bookmarks, mergedInput = []) => {
+      indexCalls.push([bookmarks, mergedInput]);
+      return originalIndex.call(searchBookmarks, bookmarks, mergedInput);
+    }) as typeof searchBookmarks.index;
+
+    const persistCalls: unknown[] = [];
+    const originalPersist = searchBookmarks.persistSnapshot;
+    searchBookmarks.persistSnapshot = (async () => {
+      persistCalls.push(undefined);
+    }) as typeof searchBookmarks.persistSnapshot;
+
+    try {
+      await synchronizeBookmarks();
+    } finally {
+      searchBookmarks.index = originalIndex;
+      searchBookmarks.persistSnapshot = originalPersist;
+      restorePipeline();
+    }
+
+    assert.strictEqual(indexCalls.length, 1);
+    assert.deepStrictEqual(indexCalls[0][0], categorized);
+    assert.deepStrictEqual(indexCalls[0][1], merged);
+    assert.strictEqual(persistCalls.length, 1);
+  });
+
+  it("logs persistence failures and resolves", async () => {
+    const chromium: Bookmark[] = [
+      {
+        id: "c-2",
+        title: "Chromium Docs",
+        url: "https://chromium.example/docs",
+        tags: ["chromium"],
+        createdAt: "2024-02-01T00:00:00.000Z"
+      }
+    ];
+
+    const firefox: Bookmark[] = [];
+
+    const merged: Bookmark[] = [...chromium];
+    const categorized: CategorizedBookmark[] = [
+      {
+        ...merged[0],
+        category: "documentation"
+      }
+    ];
+
+    const restorePipeline = stubSynchronizationPipeline({
+      chromium,
+      firefox,
+      merged,
+      categorized
+    });
+
+    const error = new Error("persist failed");
+    const originalPersist = searchBookmarks.persistSnapshot;
+    searchBookmarks.persistSnapshot = (async () => {
+      throw error;
+    }) as typeof searchBookmarks.persistSnapshot;
+
+    const originalConsoleError = console.error;
+    const calls: unknown[][] = [];
+    console.error = (...args: unknown[]) => {
+      calls.push(args);
+    };
+
+    try {
+      await synchronizeBookmarks();
+
+      assert.strictEqual(calls.length, 1);
+      assert.strictEqual(calls[0][0], "Failed to persist bookmark snapshot");
+      assert.strictEqual(calls[0][1], error);
+    } finally {
+      console.error = originalConsoleError;
+      searchBookmarks.persistSnapshot = originalPersist;
+      restorePipeline();
+    }
+  });
+});
+
+describe("bootstrapBackground", () => {
+  it("hydrates the search index before registering listeners", async () => {
+    const deferred = createDeferred<void>();
+    const originalHydrate = searchBookmarks.hydrateFromStorage;
+    let listenerRegistered = false;
+
+    searchBookmarks.hydrateFromStorage = () => deferred.promise;
+
+    const extensionAPI = {
+      runtime: {
+        onInstalled: {
+          addListener: () => {
+            listenerRegistered = true;
+          }
+        }
+      }
+    };
+
+    const bootstrapPromise = bootstrapBackground(extensionAPI);
+
+    await Promise.resolve();
+    assert.strictEqual(listenerRegistered, false);
+
+    deferred.resolve();
+
+    await bootstrapPromise;
+
+    assert.strictEqual(listenerRegistered, true);
+
+    searchBookmarks.hydrateFromStorage = originalHydrate;
+  });
+
+  it("logs hydration failures and still registers listeners", async () => {
+    const error = new Error("hydrate failure");
+    const originalHydrate = searchBookmarks.hydrateFromStorage;
+    searchBookmarks.hydrateFromStorage = () => Promise.reject(error);
+
+    let listenerRegistered = false;
+    const extensionAPI = {
+      runtime: {
+        onInstalled: {
+          addListener: () => {
+            listenerRegistered = true;
+          }
+        }
+      }
+    };
+
+    const originalConsoleError = console.error;
+    const calls: unknown[][] = [];
+    console.error = (...args: unknown[]) => {
+      calls.push(args);
+    };
+
+    try {
+      await bootstrapBackground(extensionAPI);
+
+      assert.strictEqual(calls.length, 1);
+      assert.strictEqual(
+        calls[0][0],
+        "Failed to hydrate search index from storage"
+      );
+      assert.strictEqual(calls[0][1], error);
+      assert.strictEqual(listenerRegistered, true);
+    } finally {
+      console.error = originalConsoleError;
+      searchBookmarks.hydrateFromStorage = originalHydrate;
     }
   });
 });

--- a/packages/web-extension/src/domain/models/bookmark-snapshot.ts
+++ b/packages/web-extension/src/domain/models/bookmark-snapshot.ts
@@ -1,0 +1,9 @@
+import type { Bookmark } from "./bookmark";
+import type { CategorizedBookmark } from "./categorized-bookmark";
+
+export interface BookmarkSnapshot {
+  merged?: Bookmark[];
+  categorized?: CategorizedBookmark[];
+}
+
+export const BOOKMARK_SNAPSHOT_STORAGE_KEY = "bookmarkSnapshot";

--- a/packages/web-extension/src/domain/models/categorized-bookmark.ts
+++ b/packages/web-extension/src/domain/models/categorized-bookmark.ts
@@ -1,0 +1,5 @@
+import type { Bookmark } from "./bookmark";
+
+export interface CategorizedBookmark extends Bookmark {
+  category: string;
+}

--- a/packages/web-extension/src/domain/services/__tests__/search.test.ts
+++ b/packages/web-extension/src/domain/services/__tests__/search.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { searchBookmarks } from "../search";
+import { BOOKMARK_SNAPSHOT_STORAGE_KEY } from "../../models/bookmark-snapshot";
+import type { Bookmark } from "../../models/bookmark";
+import type { CategorizedBookmark } from "../../models/categorized-bookmark";
+
+type MockStorageArea = {
+  get: (keys: string | string[] | Record<string, unknown>) => Promise<Record<string, unknown>>;
+  set: (items: Record<string, unknown>) => Promise<void>;
+};
+
+type ExtensionNamespace = {
+  storage: {
+    local?: MockStorageArea;
+    sync?: MockStorageArea;
+  };
+};
+
+type ExtensionTestGlobals = typeof globalThis & {
+  browser?: ExtensionNamespace;
+  chrome?: ExtensionNamespace;
+};
+
+const extensionGlobals = globalThis as ExtensionTestGlobals;
+
+afterEach(() => {
+  delete extensionGlobals.browser;
+  delete extensionGlobals.chrome;
+  searchBookmarks.index([], []);
+});
+
+describe("searchBookmarks storage integration", () => {
+  it("hydrates the search index from a stored snapshot", async () => {
+    const merged: Bookmark[] = [
+      {
+        id: "merged-1",
+        title: "Alpha",
+        url: "https://alpha.test",
+        tags: ["alpha"],
+        createdAt: "2024-01-01T00:00:00.000Z"
+      }
+    ];
+
+    const categorized: CategorizedBookmark[] = [
+      {
+        ...merged[0],
+        category: "reference"
+      }
+    ];
+
+    extensionGlobals.browser = {
+      storage: {
+        local: {
+          async get(key) {
+            assert.strictEqual(key, BOOKMARK_SNAPSHOT_STORAGE_KEY);
+            return {
+              [BOOKMARK_SNAPSHOT_STORAGE_KEY]: {
+                merged,
+                categorized
+              }
+            };
+          },
+          async set() {
+            throw new Error("unexpected write");
+          }
+        }
+      }
+    };
+
+    await searchBookmarks.hydrateFromStorage();
+
+    assert.deepStrictEqual(searchBookmarks.query(""), categorized);
+  });
+
+  it("persists merged and categorized snapshots to local and sync storage", async () => {
+    const merged: Bookmark[] = [
+      {
+        id: "merged-1",
+        title: "Alpha",
+        url: "https://alpha.test",
+        tags: ["alpha"],
+        createdAt: "2024-01-01T00:00:00.000Z"
+      },
+      {
+        id: "merged-2",
+        title: "Beta",
+        url: "https://beta.test",
+        tags: ["beta"],
+        createdAt: "2024-01-02T00:00:00.000Z"
+      }
+    ];
+
+    const categorized: CategorizedBookmark[] = [
+      {
+        ...merged[0],
+        category: "reference"
+      },
+      {
+        ...merged[1],
+        category: "articles"
+      }
+    ];
+
+    const calls: Array<{ area: string; items: Record<string, unknown> }> = [];
+
+    extensionGlobals.browser = {
+      storage: {
+        local: {
+          async get() {
+            return {};
+          },
+          async set(items) {
+            calls.push({ area: "local", items });
+          }
+        },
+        sync: {
+          async get() {
+            return {};
+          },
+          async set(items) {
+            calls.push({ area: "sync", items });
+          }
+        }
+      }
+    };
+
+    searchBookmarks.index(categorized, merged);
+
+    await searchBookmarks.persistSnapshot();
+
+    assert.strictEqual(calls.length, 2);
+    assert.deepStrictEqual(calls[0], {
+      area: "local",
+      items: {
+        [BOOKMARK_SNAPSHOT_STORAGE_KEY]: {
+          merged,
+          categorized
+        }
+      }
+    });
+    assert.deepStrictEqual(calls[1], {
+      area: "sync",
+      items: {
+        [BOOKMARK_SNAPSHOT_STORAGE_KEY]: {
+          merged,
+          categorized
+        }
+      }
+    });
+  });
+
+  it("hydrates from sync storage when the local area is empty", async () => {
+    const merged: Bookmark[] = [
+      {
+        id: "merged-3",
+        title: "Gamma",
+        url: "https://gamma.test",
+        tags: ["gamma"],
+        createdAt: "2024-01-03T00:00:00.000Z"
+      }
+    ];
+
+    const categorized: CategorizedBookmark[] = [
+      {
+        ...merged[0],
+        category: "reading"
+      }
+    ];
+
+    let localGetCount = 0;
+
+    extensionGlobals.browser = {
+      storage: {
+        local: {
+          async get() {
+            localGetCount += 1;
+            return {};
+          },
+          async set() {
+            throw new Error("unexpected write");
+          }
+        },
+        sync: {
+          async get() {
+            return {
+              [BOOKMARK_SNAPSHOT_STORAGE_KEY]: {
+                merged,
+                categorized
+              }
+            };
+          },
+          async set() {
+            throw new Error("unexpected write");
+          }
+        }
+      }
+    };
+
+    await searchBookmarks.hydrateFromStorage();
+
+    assert.strictEqual(localGetCount, 1);
+    assert.deepStrictEqual(searchBookmarks.query(""), categorized);
+  });
+});

--- a/packages/web-extension/src/domain/services/categorizer.ts
+++ b/packages/web-extension/src/domain/services/categorizer.ts
@@ -1,8 +1,5 @@
 import { Bookmark } from "../models/bookmark";
-
-export interface CategorizedBookmark extends Bookmark {
-  category: string;
-}
+import type { CategorizedBookmark } from "../models/categorized-bookmark";
 
 export function categorizeBookmarks(bookmarks: Bookmark[]): CategorizedBookmark[] {
   return bookmarks.map((bookmark) => ({

--- a/packages/web-extension/src/domain/services/llm-categorizer.ts
+++ b/packages/web-extension/src/domain/services/llm-categorizer.ts
@@ -1,6 +1,7 @@
 import type { Bookmark } from "../models/bookmark";
+import type { CategorizedBookmark } from "../models/categorized-bookmark";
 import type { LLMConfiguration } from "../models/llm-configuration";
-import { categorizeBookmarks, type CategorizedBookmark } from "./categorizer";
+import { categorizeBookmarks } from "./categorizer";
 import { loadLLMConfiguration } from "./llm-settings";
 
 interface LLMRequestPayload {

--- a/packages/web-extension/src/domain/services/search.ts
+++ b/packages/web-extension/src/domain/services/search.ts
@@ -1,10 +1,18 @@
-import { CategorizedBookmark } from "./categorizer";
+import type { Bookmark } from "../models/bookmark";
+import type { CategorizedBookmark } from "../models/categorized-bookmark";
+import {
+  BOOKMARK_SNAPSHOT_STORAGE_KEY,
+  type BookmarkSnapshot
+} from "../models/bookmark-snapshot";
+import { getItem, setItem } from "./extension-storage";
 
 class SearchIndex {
   private items: CategorizedBookmark[] = [];
+  private merged: Bookmark[] = [];
 
-  public index(bookmarks: CategorizedBookmark[]): void {
-    this.items = bookmarks;
+  public index(bookmarks: CategorizedBookmark[], merged: Bookmark[] = []): void {
+    this.items = [...bookmarks];
+    this.merged = [...merged];
   }
 
   public query(term: string): CategorizedBookmark[] {
@@ -15,6 +23,45 @@ class SearchIndex {
         bookmark.url.toLowerCase().includes(normalizedTerm) ||
         bookmark.category.toLowerCase().includes(normalizedTerm)
       );
+    });
+  }
+
+  private serialize(): BookmarkSnapshot {
+    return {
+      merged: [...this.merged],
+      categorized: [...this.items]
+    };
+  }
+
+  private deserialize(snapshot: BookmarkSnapshot | null): void {
+    if (!snapshot) {
+      this.items = [];
+      this.merged = [];
+      return;
+    }
+
+    this.items = Array.isArray(snapshot.categorized)
+      ? [...snapshot.categorized]
+      : [];
+
+    this.merged = Array.isArray(snapshot.merged)
+      ? [...snapshot.merged]
+      : [];
+  }
+
+  public async hydrateFromStorage(): Promise<void> {
+    const snapshot = await getItem(BOOKMARK_SNAPSHOT_STORAGE_KEY, {
+      area: ["local", "sync"]
+    });
+
+    this.deserialize(snapshot);
+  }
+
+  public async persistSnapshot(): Promise<void> {
+    const snapshot = this.serialize();
+
+    await setItem(BOOKMARK_SNAPSHOT_STORAGE_KEY, snapshot, {
+      area: ["local", "sync"]
     });
   }
 }

--- a/packages/web-extension/src/popup/__tests__/index.test.ts
+++ b/packages/web-extension/src/popup/__tests__/index.test.ts
@@ -1,9 +1,57 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import ReactDOM from "react-dom";
 
 describe("popup entrypoint", () => {
   it("renders the App component into the root element", async () => {
+    const Module = require("module") as {
+      _load: (request: string, parent: unknown, isMain: boolean) => unknown;
+    };
+    const originalModuleLoad = Module._load;
+
+    Module._load = (request, parent, isMain) => {
+      if (request === "react") {
+        return {
+          useState<S>(initial: S | (() => S)) {
+            const resolved =
+              typeof initial === "function"
+                ? (initial as () => S)()
+                : initial;
+            let state = resolved;
+            const setState = (value: S | ((prev: S) => S)) => {
+              state =
+                typeof value === "function"
+                  ? (value as (prev: S) => S)(state)
+                  : value;
+            };
+            return [state, setState] as const;
+          },
+          useEffect(effect: () => void | (() => void)) {
+            const cleanup = effect();
+            if (typeof cleanup === "function") {
+              cleanup();
+            }
+          },
+          useMemo<T>(factory: () => T) {
+            return factory();
+          }
+        };
+      }
+
+      if (request === "react/jsx-runtime") {
+        return {
+          jsx(type: unknown, props: Record<string, unknown>, key?: unknown) {
+            return { type, props, key };
+          },
+          jsxs(type: unknown, props: Record<string, unknown>, key?: unknown) {
+            return { type, props, key };
+          },
+          Fragment: Symbol.for("react.fragment")
+        };
+      }
+
+      return originalModuleLoad(request, parent, isMain);
+    };
+
     const { App } = await import("../App");
 
     const rootElement = {} as unknown as HTMLElement;
@@ -28,21 +76,25 @@ describe("popup entrypoint", () => {
     globalScope.document = fakeDocument as unknown as Document;
 
     const renderCalls: Array<[unknown, unknown, unknown?]> = [];
-    const originalRender = ReactDOM.render;
-
-    (ReactDOM as unknown as {
-      render: typeof originalRender;
-    }).render = ((
-      element: unknown,
-      container: Element | DocumentFragment | null,
-      callback?: () => void
-    ) => {
-      renderCalls.push([element, container, callback]);
-      if (callback) {
-        callback();
+    const stubbedReactDOM = {
+      render(
+        element: unknown,
+        container: Element | DocumentFragment | null,
+        callback?: () => void
+      ) {
+        renderCalls.push([element, container, callback]);
+        if (callback) {
+          callback();
+        }
+        return null as never;
       }
-      return null as never;
-    }) as typeof originalRender;
+    };
+
+    const stubGlobal = globalScope as typeof globalScope & {
+      __capybaraReactDOMStub__?: typeof stubbedReactDOM;
+    };
+    const previousStub = stubGlobal.__capybaraReactDOMStub__;
+    stubGlobal.__capybaraReactDOMStub__ = stubbedReactDOM;
 
     try {
       await import("../index");
@@ -55,8 +107,12 @@ describe("popup entrypoint", () => {
       assert.ok(element && typeof element === "object");
       assert.strictEqual((element as { type?: unknown }).type, App);
     } finally {
-      (ReactDOM as unknown as { render: typeof originalRender }).render =
-        originalRender;
+      Module._load = originalModuleLoad;
+      if (previousStub) {
+        stubGlobal.__capybaraReactDOMStub__ = previousStub;
+      } else {
+        delete stubGlobal.__capybaraReactDOMStub__;
+      }
 
       if (hadDocument) {
         globalScope.document = previousDocument;

--- a/packages/web-extension/src/popup/index.tsx
+++ b/packages/web-extension/src/popup/index.tsx
@@ -1,4 +1,4 @@
-import ReactDOM from "react-dom";
+import ReactDOM from "./react-dom-adapter";
 import { App } from "./App";
 
 const rootElement = document.getElementById("root");

--- a/packages/web-extension/src/popup/react-dom-adapter.ts
+++ b/packages/web-extension/src/popup/react-dom-adapter.ts
@@ -1,0 +1,63 @@
+type ReactDOMLike = {
+  render: (
+    element: unknown,
+    container: Element | DocumentFragment | null,
+    callback?: () => void
+  ) => unknown;
+};
+
+type GlobalWithStub = typeof globalThis & {
+  __capybaraReactDOMStub__?: ReactDOMLike;
+};
+
+const globalScope = globalThis as GlobalWithStub;
+
+let cachedImplementation: ReactDOMLike | null = null;
+
+function resolveImplementation(): ReactDOMLike {
+  const stub = globalScope.__capybaraReactDOMStub__;
+  if (stub) {
+    return stub;
+  }
+
+  if (cachedImplementation) {
+    return cachedImplementation;
+  }
+
+  try {
+    const required = require("react-dom") as
+      | ReactDOMLike
+      | { default?: ReactDOMLike };
+
+    if (required && typeof (required as ReactDOMLike).render === "function") {
+      cachedImplementation = required as ReactDOMLike;
+      return cachedImplementation;
+    }
+
+    const defaultExport = (required as { default?: ReactDOMLike })?.default;
+    if (defaultExport && typeof defaultExport.render === "function") {
+      cachedImplementation = defaultExport;
+      return cachedImplementation;
+    }
+  } catch (error) {
+    // Swallow resolution failures so tests can provide a stub implementation.
+  }
+
+  const fallback: ReactDOMLike = {
+    render() {
+      throw new Error("ReactDOM render is unavailable");
+    }
+  };
+
+  cachedImplementation = fallback;
+  return fallback;
+}
+
+const reactDomAdapter: ReactDOMLike = {
+  render(element, container, callback) {
+    const implementation = resolveImplementation();
+    return implementation.render(element, container, callback);
+  }
+};
+
+export default reactDomAdapter;

--- a/packages/web-extension/src/types/node-test.d.ts
+++ b/packages/web-extension/src/types/node-test.d.ts
@@ -14,3 +14,5 @@ declare module "node:assert/strict" {
   const assert: AssertModule;
   export default assert;
 }
+
+declare function require(moduleName: string): unknown;

--- a/packages/web-extension/src/types/webextension.d.ts
+++ b/packages/web-extension/src/types/webextension.d.ts
@@ -5,6 +5,7 @@ interface BrowserStorageArea {
 
 interface BrowserStorage {
   local: BrowserStorageArea;
+  sync?: BrowserStorageArea;
 }
 
 interface BrowserRuntimeEvent {


### PR DESCRIPTION
## Summary
- persist merged and categorized bookmark snapshots via the search service using extension storage
- load the cached snapshot before registering background listeners and log persistence failures during sync
- cover snapshot hydration/persistence and background bootstrap logic with new unit tests while stubbing React/DOM modules for popup tests

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d02cae6a60832aa67308d4d8f3d3a7