### PR TITLE
Keep background bookmark sync active when disabled

### DIFF
--- a/packages/web-extension/src/background/index.ts
+++ b/packages/web-extension/src/background/index.ts
@@ -3,7 +3,6 @@ import { categorizeBookmarksWithLLM } from "../domain/services/llm-categorizer";
 import { searchBookmarks } from "../domain/services/search";
 import { fetchChromiumBookmarks } from "./bookmark-sync/chromium-provider";
 import { fetchFirefoxBookmarks } from "./bookmark-sync/firefox-provider";
-import { loadSyncSettings } from "../domain/services/sync-settings";
 
 export const BOOKMARK_SYNC_ALARM_NAME = "capybara::bookmark-sync";
 export const BOOKMARK_SYNC_ALARM_PERIOD_MINUTES = 30;
@@ -32,19 +31,6 @@ export type BackgroundExtensionAPI = {
 };
 
 export async function synchronizeBookmarks(): Promise<void> {
-  let settings: { enabled: boolean };
-
-  try {
-    settings = await loadSyncSettings();
-  } catch (error) {
-    console.error("Failed to load synchronization settings", error);
-    settings = { enabled: false };
-  }
-
-  if (!settings.enabled) {
-    return;
-  }
-
   const [chromiumBookmarks, firefoxBookmarks] = await Promise.all([
     fetchChromiumBookmarks(),
     fetchFirefoxBookmarks()


### PR DESCRIPTION
## Summary
- remove the early return that skipped synchronization when sync settings are disabled so bookmarks are always merged and indexed
- extend the background tests to verify disabled sync still indexes bookmarks and only local persistence occurs

## Testing
- `npm --prefix packages/web-extension test` *(fails: missing esbuild dependency due to offline registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68d05580ac50832a98b4ef78a65196a7