### PR TITLE
Trigger manual bookmark sync after saving settings

### DIFF
--- a/packages/web-extension/src/shared/runtime-messages.ts
+++ b/packages/web-extension/src/shared/runtime-messages.ts
@@ -1,0 +1,15 @@
+export const RUNTIME_SYNC_NOW_MESSAGE_TYPE = "capybara::sync-now" as const;
+
+export type RuntimeSyncNowMessage = {
+  type: typeof RUNTIME_SYNC_NOW_MESSAGE_TYPE;
+};
+
+export function isRuntimeSyncNowMessage(
+  message: unknown
+): message is RuntimeSyncNowMessage {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    (message as { type?: unknown }).type === RUNTIME_SYNC_NOW_MESSAGE_TYPE
+  );
+}


### PR DESCRIPTION
## Summary
- send a runtime message from the options page after synchronization settings are saved
- listen for the manual synchronization runtime message in the background worker and reuse a shared helper to identify it
- add unit coverage to ensure the new runtime message triggers synchronization

## Testing
- npm test *(fails: requires the esbuild package which is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d061fb4358832aa4cde67336402d4e