### PR TITLE
Add options page entrypoint to extension

### DIFF
--- a/packages/web-extension/manifest.json
+++ b/packages/web-extension/manifest.json
@@ -9,6 +9,10 @@
   "background": {
     "service_worker": "dist/background/index.js"
   },
+  "options_ui": {
+    "page": "dist/options/index.html",
+    "open_in_tab": true
+  },
   "permissions": [
     "bookmarks",
     "storage"

--- a/packages/web-extension/public/options.html
+++ b/packages/web-extension/public/options.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Capybara Options</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="./index.js" defer></script>
+  </body>
+</html>

--- a/packages/web-extension/scripts/build.mjs
+++ b/packages/web-extension/scripts/build.mjs
@@ -27,7 +27,7 @@ async function collectEntries() {
   const candidates = [
     resolveEntry(path.join("background", "index.ts")),
     resolveEntry(path.join("popup", "index.tsx")),
-    resolveEntry(path.join("options", "settings.tsx"))
+    resolveEntry(path.join("options", "index.tsx"))
   ];
 
   const entries = {};
@@ -77,6 +77,10 @@ async function copyPublicAssets() {
         const popupDestination = path.join(distDirectory, "popup");
         await mkdir(popupDestination, { recursive: true });
         await copyFile(source, path.join(popupDestination, "index.html"));
+      } else if (asset.name === "options.html") {
+        const optionsDestination = path.join(distDirectory, "options");
+        await mkdir(optionsDestination, { recursive: true });
+        await copyFile(source, path.join(optionsDestination, "index.html"));
       } else {
         const destination = path.join(distDirectory, asset.name);
         await mkdir(path.dirname(destination), { recursive: true });

--- a/packages/web-extension/src/options/index.tsx
+++ b/packages/web-extension/src/options/index.tsx
@@ -1,0 +1,10 @@
+import ReactDOM from "../popup/react-dom-adapter";
+import { Settings } from "./settings";
+
+const rootElement = document.getElementById("root");
+
+if (!rootElement) {
+  throw new Error("Failed to locate the options root element.");
+}
+
+ReactDOM.render(<Settings />, rootElement);

--- a/scripts/package-extension.js
+++ b/scripts/package-extension.js
@@ -53,6 +53,14 @@ async function copyPublicAssets(publicDirectory, extensionDirectory) {
           );
           await fs.mkdir(popupDestination, { recursive: true });
           await fs.copyFile(source, path.join(popupDestination, "index.html"));
+        } else if (asset.name === "options.html") {
+          const optionsDestination = path.join(
+            extensionDirectory,
+            "dist",
+            "options"
+          );
+          await fs.mkdir(optionsDestination, { recursive: true });
+          await fs.copyFile(source, path.join(optionsDestination, "index.html"));
         } else {
           await fs.copyFile(source, destination);
         }


### PR DESCRIPTION
## Summary
- add an options page React entrypoint that renders the Settings view
- ship an options HTML shell during build/packaging and register it in the manifest

## Testing
- npm run build *(fails: cannot download esbuild from npm registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0736d9bb0832abf2e78bf1d2b9945