### PR TITLE
feat: validate LLM endpoints and permissions

### DIFF
--- a/packages/web-extension/manifest.json
+++ b/packages/web-extension/manifest.json
@@ -19,5 +19,8 @@
   ],
   "host_permissions": [
     "https://api.openai.com/*"
+  ],
+  "optional_host_permissions": [
+    "https://*/*"
   ]
 }

--- a/packages/web-extension/src/shared/extension-permissions.ts
+++ b/packages/web-extension/src/shared/extension-permissions.ts
@@ -1,0 +1,134 @@
+interface HostPermissions {
+  origins?: string[];
+}
+
+type PermissionsCallback = (
+  permissions: HostPermissions,
+  callback: (granted: boolean) => void
+) => void;
+
+type PermissionsPromise = (permissions: HostPermissions) => Promise<boolean> | boolean;
+
+type PermissionsMethod = PermissionsCallback | PermissionsPromise;
+
+interface ExtensionPermissions {
+  contains?: PermissionsMethod;
+  request?: PermissionsMethod;
+}
+
+type ExtensionGlobals = typeof globalThis & {
+  browser?: { permissions?: ExtensionPermissions };
+  chrome?: { permissions?: ExtensionPermissions };
+};
+
+export interface HostPermissionInfo {
+  href: string;
+  origin: string;
+  pattern: string;
+}
+
+function getPermissionsAPI(): ExtensionPermissions | null {
+  const globals = globalThis as ExtensionGlobals;
+  return globals.browser?.permissions ?? globals.chrome?.permissions ?? null;
+}
+
+function callPermissionsMethod(
+  method: PermissionsMethod | undefined,
+  origins: string[]
+): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    if (!method) {
+      resolve(false);
+      return;
+    }
+
+    try {
+      if (method.length > 1) {
+        (method as PermissionsCallback)({ origins }, (granted) => resolve(Boolean(granted)));
+        return;
+      }
+
+      const result = (method as PermissionsPromise)({ origins });
+
+      if (result && typeof (result as Promise<boolean>).then === "function") {
+        (result as Promise<boolean>).then(
+          (value) => resolve(Boolean(value)),
+          (error) => reject(error)
+        );
+        return;
+      }
+
+      resolve(Boolean(result));
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+export function getHostPermissionInfo(endpoint: string): HostPermissionInfo | null {
+  const trimmed = endpoint.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  try {
+    const url = new URL(trimmed);
+
+    if (url.protocol !== "https:" || !url.hostname || url.hostname.trim().length === 0) {
+      return null;
+    }
+
+    if (url.username || url.password) {
+      return null;
+    }
+
+    return {
+      href: url.toString(),
+      origin: url.origin,
+      pattern: `${url.origin}/*`
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function hasHostPermission(pattern: string): Promise<boolean> {
+  const permissions = getPermissionsAPI();
+  if (!permissions?.contains) {
+    return true;
+  }
+
+  try {
+    return await callPermissionsMethod(permissions.contains, [pattern]);
+  } catch {
+    return false;
+  }
+}
+
+export async function ensureHostPermission(pattern: string): Promise<boolean> {
+  const permissions = getPermissionsAPI();
+  if (!permissions) {
+    return true;
+  }
+
+  if (permissions.contains) {
+    try {
+      const alreadyGranted = await callPermissionsMethod(permissions.contains, [pattern]);
+      if (alreadyGranted) {
+        return true;
+      }
+    } catch {
+      // If the permissions API throws we fall back to requesting explicit access.
+    }
+  }
+
+  if (!permissions.request) {
+    return false;
+  }
+
+  try {
+    return await callPermissionsMethod(permissions.request, [pattern]);
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- allow dynamic LLM endpoints by registering optional host permissions in the manifest
- add shared helpers to derive host permission patterns, check existing grants, and request access
- validate the configured LLM endpoint in the options UI, request permissions, and fall back gracefully in the categorizer when validation or permissions fail
- extend the LLM categorizer tests to cover invalid endpoints and missing host permissions

## Testing
- `npm run test` *(fails: tsx command is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0a1009810832ab718b8cacc4e7de5