### PR TITLE
feat(web-extension): allow overriding sync settings loader

### DIFF
--- a/packages/web-extension/src/domain/services/__tests__/search.test.ts
+++ b/packages/web-extension/src/domain/services/__tests__/search.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { searchBookmarks } from "../search";
+import {
+  resetSearchSyncSettingsLoader,
+  searchBookmarks,
+  setSearchSyncSettingsLoader
+} from "../search";
 import { BOOKMARK_SNAPSHOT_STORAGE_KEY } from "../../models/bookmark-snapshot";
 import type { Bookmark } from "../../models/bookmark";
 import type { CategorizedBookmark } from "../../models/categorized-bookmark";
@@ -26,18 +30,15 @@ type ExtensionTestGlobals = typeof globalThis & {
 };
 
 const extensionGlobals = globalThis as ExtensionTestGlobals;
-const syncSettingsModule: any = require("../sync-settings");
-const originalLoadSyncSettings = syncSettingsModule.loadSyncSettings as () => Promise<SyncSettings>;
-
 function stubSyncSettings(settings: SyncSettings): void {
-  syncSettingsModule.loadSyncSettings = async () => settings;
+  setSearchSyncSettingsLoader(async () => settings);
 }
 
 afterEach(() => {
   delete extensionGlobals.browser;
   delete extensionGlobals.chrome;
   searchBookmarks.index([], []);
-  syncSettingsModule.loadSyncSettings = originalLoadSyncSettings;
+  resetSearchSyncSettingsLoader();
 });
 
 describe("searchBookmarks storage integration", () => {

--- a/packages/web-extension/src/domain/services/search.ts
+++ b/packages/web-extension/src/domain/services/search.ts
@@ -5,13 +5,27 @@ import {
   type BookmarkSnapshot,
   type BookmarkSnapshotStorageValue
 } from "../models/bookmark-snapshot";
-import { loadSyncSettings } from "./sync-settings";
+import { loadSyncSettings as defaultLoadSyncSettings } from "./sync-settings";
 import { getItem, setItem } from "./extension-storage";
 import {
   decryptBookmarkSnapshot,
   encryptBookmarkSnapshot,
   type BookmarkSnapshotEncryptionContext
 } from "./bookmark-snapshot-crypto";
+
+type SyncSettingsLoader = typeof defaultLoadSyncSettings;
+
+let loadSyncSettings: SyncSettingsLoader = defaultLoadSyncSettings;
+
+export function setSearchSyncSettingsLoader(
+  loader: SyncSettingsLoader
+): void {
+  loadSyncSettings = loader;
+}
+
+export function resetSearchSyncSettingsLoader(): void {
+  loadSyncSettings = defaultLoadSyncSettings;
+}
 
 class SearchIndex {
   private items: CategorizedBookmark[] = [];


### PR DESCRIPTION
## Summary
- expose setter/reset helpers for the sync settings loader so search indexing logic can be tested without mutating ESM exports
- allow the background synchronizer to receive injected bookmark providers/merger/LLM categorizer implementations for deterministic tests
- refactor the background and search test suites to use the new hooks in place of reassignment

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a99f1d78832a87da8b36bdd8d289