### PR TITLE
Fix verify script options entry path

### DIFF
--- a/packages/web-extension/scripts/verify-jsx-build.mjs
+++ b/packages/web-extension/scripts/verify-jsx-build.mjs
@@ -27,8 +27,8 @@ const buildEntries = [
     output: path.join(distDirectory, "popup", "index.js")
   },
   {
-    source: path.join(srcDirectory, "options", "settings.tsx"),
-    output: path.join(distDirectory, "options", "settings.js")
+    source: path.join(srcDirectory, "options", "index.tsx"),
+    output: path.join(distDirectory, "options", "index.js")
   }
 ];
 


### PR DESCRIPTION
## Summary
- update the verify-jsx-build script to check the options bundle produced from the index entry

## Testing
- npm run verify:jsx


------
https://chatgpt.com/codex/tasks/task_e_68d0ae6f1710832aa242d6302e44960d