### PR TITLE
Add Docker tooling for Chrome-enabled tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+FROM node:lts
+
+# Install Chromium for headless browser testing
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        chromium \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV CHROME_BIN=/usr/bin/chromium
+
+WORKDIR /usr/src/app
+
+# Copy repository contents into the container
+COPY . .
+
+# Install dependencies for the web extension package
+RUN cd packages/web-extension && npm install
+
+# Default working directory for runtime commands
+WORKDIR /usr/src/app/packages/web-extension
+
+# Run the test suite by default when the container starts
+CMD ["npm", "run", "test"]

--- a/README.md
+++ b/README.md
@@ -40,3 +40,37 @@ A deeper architectural breakdown is available in [`docs/architecture/overview.md
 Detailed guidance lives in the [`docs/`](docs/README.md) directory, covering architecture decisions, synchronization protocol notes, UX expectations, and operational playbooks.
 
 Contributions are welcome—open an issue or pull request describing the problem you are solving, reference the relevant docs, and keep the README up to date as capabilities evolve.
+
+## Docker usage
+
+Run the browser-enabled test environment in Docker when you want an isolated Chromium install or a reproducible CI-like setup.
+
+### Build the image
+
+```bash
+docker compose build
+```
+
+### Execute the test suite
+
+Run the default `npm run test` command inside the container:
+
+```bash
+docker compose run --rm web-extension
+```
+
+To keep the container alive for repeated runs (for example, while debugging against the exposed Chrome DevTools port 9222), start it in attached mode:
+
+```bash
+docker compose up
+```
+
+Test results are streamed to your terminal output. Repository changes in your local workspace are mounted into the container, so edits on the host are immediately reflected inside Docker.
+
+For a one-step wrapper, use the optional helper script:
+
+```bash
+./scripts/run-docker-tests.sh
+```
+
+Pass additional arguments to run different commands, e.g., `./scripts/run-docker-tests.sh npm run build`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  web-extension:
+    build:
+      context: .
+    working_dir: /usr/src/app/packages/web-extension
+    command: npm run test
+    volumes:
+      - .:/usr/src/app
+      - node_modules:/usr/src/app/packages/web-extension/node_modules
+    ports:
+      - "9222:9222"
+volumes:
+  node_modules:

--- a/scripts/run-docker-tests.sh
+++ b/scripts/run-docker-tests.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="$REPO_ROOT/docker-compose.yml"
+SERVICE_NAME="web-extension"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required but was not found in PATH." >&2
+  exit 1
+fi
+
+COMPOSE_COMMAND=(docker compose)
+
+if [ ! -f "$COMPOSE_FILE" ]; then
+  echo "docker-compose.yml not found at $COMPOSE_FILE" >&2
+  exit 1
+fi
+
+if [ "$#" -gt 0 ]; then
+  exec "${COMPOSE_COMMAND[@]}" -f "$COMPOSE_FILE" run --rm "$SERVICE_NAME" "$@"
+else
+  exec "${COMPOSE_COMMAND[@]}" -f "$COMPOSE_FILE" run --rm "$SERVICE_NAME"
+fi


### PR DESCRIPTION
## Summary
- add a Node LTS-based Dockerfile that installs Chromium and runs the web-extension tests by default
- introduce a docker-compose setup with live code mounting and a Chrome debugging port
- document Docker workflows and provide a helper script to run the containerized tests

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d0be834540832a8d1e67dfd208de82