### PR TITLE
Normalize microsecond bookmark timestamps

### DIFF
--- a/packages/web-extension/src/background/bookmark-sync/__tests__/bookmark-tree.test.ts
+++ b/packages/web-extension/src/background/bookmark-sync/__tests__/bookmark-tree.test.ts
@@ -63,6 +63,45 @@ describe("flattenBookmarkTree", () => {
     ]);
   });
 
+  it("normalizes microsecond-based Chromium timestamps", () => {
+    const timestampInMilliseconds = 1716230400000;
+    const timestampInMicroseconds = timestampInMilliseconds * 1000;
+
+    const chromiumTree: BookmarkTreeNode[] = [
+      {
+        id: "0",
+        title: "",
+        children: [
+          {
+            id: "1",
+            title: "Bookmarks bar",
+            children: [
+              {
+                id: "100",
+                title: "Example Domain",
+                url: "https://example.com",
+                dateAdded: timestampInMicroseconds
+              }
+            ]
+          }
+        ]
+      }
+    ];
+
+    const bookmarks = flattenBookmarkTree(chromiumTree, "chromium");
+
+    assert.deepStrictEqual(bookmarks, [
+      {
+        id: "100",
+        title: "Example Domain",
+        url: "https://example.com",
+        tags: [],
+        createdAt: new Date(timestampInMilliseconds).toISOString(),
+        source: "chromium"
+      }
+    ]);
+  });
+
   it("normalizes Firefox bookmark tree payloads", () => {
     const firstTimestamp = 1716403200000;
     const secondTimestamp = 1716489600000;

--- a/packages/web-extension/src/background/bookmark-sync/bookmark-tree.ts
+++ b/packages/web-extension/src/background/bookmark-sync/bookmark-tree.ts
@@ -75,5 +75,14 @@ function collectTags(node: BookmarkTreeNode): string[] {
 
 function toIsoDate(dateAdded?: number): string {
   const timestamp = typeof dateAdded === "number" ? dateAdded : 0;
-  return new Date(timestamp).toISOString();
+  const MICROSECOND_THRESHOLD = 1e12;
+
+  const isMicrosecondTimestamp =
+    timestamp >= MICROSECOND_THRESHOLD && timestamp.toString().length > 13;
+
+  const normalizedTimestamp = isMicrosecondTimestamp
+    ? Math.floor(timestamp / 1000)
+    : timestamp;
+
+  return new Date(normalizedTimestamp).toISOString();
 }


### PR DESCRIPTION
## Summary
- normalize bookmark timestamps by detecting microsecond inputs before generating ISO strings
- add a Chromium bookmark-tree test that covers microsecond dateAdded normalization

## Testing
- npm run test (from packages/web-extension)


------
https://chatgpt.com/codex/tasks/task_e_68d0c323a468832a9d9871214d7eed97