### PR TITLE
Hydrate popup search on mount and add hydration test

### DIFF
--- a/packages/web-extension/src/popup/App.tsx
+++ b/packages/web-extension/src/popup/App.tsx
@@ -1,9 +1,29 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { searchBookmarks } from "../domain/services/search";
 
 export function App(): JSX.Element {
   const [query, setQuery] = useState("");
-  const results = useMemo(() => searchBookmarks.query(query), [query]);
+  const [hasHydrated, setHasHydrated] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    void (async () => {
+      try {
+        await searchBookmarks.hydrateFromStorage();
+      } finally {
+        if (isMounted) {
+          setHasHydrated(true);
+        }
+      }
+    })();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const results = useMemo(() => searchBookmarks.query(query), [query, hasHydrated]);
 
   return (
     <main>

--- a/packages/web-extension/src/popup/__tests__/index.test.ts
+++ b/packages/web-extension/src/popup/__tests__/index.test.ts
@@ -1,6 +1,191 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
+declare const __filename: string;
+
+type ReactElement = {
+  type: unknown;
+  key?: unknown;
+  props: { children?: unknown; [key: string]: unknown };
+};
+
+type RequireFunction = ((specifier: string) => unknown) & {
+  resolve: (specifier: string) => string;
+};
+
+const createHookEnvironment = () => {
+  let component: (() => ReactElement) | null = null;
+  let currentTree: ReactElement | null = null;
+  const stateValues: unknown[] = [];
+  const memoValues: unknown[] = [];
+  const memoDeps: Array<unknown[] | undefined> = [];
+  const effectStates: Array<{ deps?: unknown[]; cleanup?: (() => void) }> = [];
+  const pendingEffects: Array<() => void | (() => void)> = [];
+  const pendingEffectIndices: number[] = [];
+  let stateIndex = 0;
+  let memoIndex = 0;
+  let effectIndex = 0;
+
+  const flushEffects = () => {
+    while (pendingEffects.length > 0) {
+      const effect = pendingEffects.shift()!;
+      const index = pendingEffectIndices.shift()!;
+      const previous = effectStates[index];
+      if (previous?.cleanup) {
+        previous.cleanup();
+      }
+      const cleanup = effect();
+      effectStates[index] = {
+        deps: effectStates[index]?.deps,
+        cleanup: typeof cleanup === "function" ? cleanup : undefined
+      };
+    }
+  };
+
+  const queueRender = () => {
+    if (!component) {
+      throw new Error("No component registered.");
+    }
+
+    stateIndex = 0;
+    memoIndex = 0;
+    effectIndex = 0;
+    pendingEffects.length = 0;
+    pendingEffectIndices.length = 0;
+    currentTree = component();
+
+    flushEffects();
+  };
+
+  const react = {
+    useState<S>(initial: S | (() => S)) {
+      const index = stateIndex++;
+      if (stateValues.length <= index) {
+        stateValues[index] =
+          typeof initial === "function"
+            ? (initial as () => S)()
+            : initial;
+      }
+
+      const setState = (value: S | ((prev: S) => S)) => {
+        const previous = stateValues[index] as S;
+        const next =
+          typeof value === "function"
+            ? (value as (prev: S) => S)(previous)
+            : value;
+
+        if (!Object.is(previous, next)) {
+          stateValues[index] = next;
+          queueRender();
+        }
+      };
+
+      return [stateValues[index] as S, setState] as const;
+    },
+    useEffect(effect: () => void | (() => void), deps?: unknown[]) {
+      const index = effectIndex++;
+      const previous = effectStates[index];
+      const depsChanged =
+        !deps ||
+        !previous?.deps ||
+        deps.length !== previous.deps.length ||
+        deps.some((dep, depIndex) => !Object.is(dep, previous.deps![depIndex]));
+
+      effectStates[index] = { deps, cleanup: previous?.cleanup };
+
+      if (depsChanged) {
+        pendingEffectIndices.push(index);
+        pendingEffects.push(effect);
+      }
+    },
+    useMemo<T>(factory: () => T, deps?: unknown[]) {
+      const index = memoIndex++;
+      const previousDeps = memoDeps[index];
+
+      if (
+        !deps ||
+        !previousDeps ||
+        deps.length !== previousDeps.length ||
+        deps.some((dep, depIndex) => !Object.is(dep, previousDeps[depIndex]))
+      ) {
+        memoValues[index] = factory();
+        memoDeps[index] = deps ? [...deps] : undefined;
+      }
+
+      return memoValues[index] as T;
+    }
+  };
+
+  const jsxRuntime = {
+    jsx(type: unknown, props: Record<string, unknown>, key?: unknown) {
+      return { type, props, key };
+    },
+    jsxs(type: unknown, props: Record<string, unknown>, key?: unknown) {
+      return { type, props, key };
+    },
+    Fragment: Symbol.for("react.fragment")
+  };
+
+  return {
+    react,
+    jsxRuntime,
+    render(renderComponent: () => ReactElement) {
+      component = renderComponent;
+      queueRender();
+      return currentTree as ReactElement;
+    },
+    getTree() {
+      if (!currentTree) {
+        throw new Error("No tree available.");
+      }
+      return currentTree;
+    },
+    reset() {
+      component = null;
+      currentTree = null;
+      stateValues.length = 0;
+      memoValues.length = 0;
+      memoDeps.length = 0;
+      effectStates.length = 0;
+      pendingEffects.length = 0;
+      pendingEffectIndices.length = 0;
+      stateIndex = 0;
+      memoIndex = 0;
+      effectIndex = 0;
+    }
+  };
+};
+
+const toChildArray = (children: unknown): unknown[] => {
+  if (Array.isArray(children)) {
+    return children;
+  }
+
+  if (children === null || children === undefined) {
+    return [];
+  }
+
+  return [children];
+};
+
+const collectElements = (
+  element: ReactElement,
+  predicate: (candidate: ReactElement) => boolean,
+  results: ReactElement[]
+) => {
+  if (predicate(element)) {
+    results.push(element);
+  }
+
+  for (const child of toChildArray(element.props.children)) {
+    if (child && typeof child === "object") {
+      collectElements(child as ReactElement, predicate, results);
+    }
+  }
+};
+
+const sharedHooks = createHookEnvironment();
+
 describe("popup entrypoint", () => {
   it("renders the App component into the root element", async () => {
     const Module = require("module") as {
@@ -8,45 +193,14 @@ describe("popup entrypoint", () => {
     };
     const originalModuleLoad = Module._load;
 
+    sharedHooks.reset();
     Module._load = (request, parent, isMain) => {
       if (request === "react") {
-        return {
-          useState<S>(initial: S | (() => S)) {
-            const resolved =
-              typeof initial === "function"
-                ? (initial as () => S)()
-                : initial;
-            let state = resolved;
-            const setState = (value: S | ((prev: S) => S)) => {
-              state =
-                typeof value === "function"
-                  ? (value as (prev: S) => S)(state)
-                  : value;
-            };
-            return [state, setState] as const;
-          },
-          useEffect(effect: () => void | (() => void)) {
-            const cleanup = effect();
-            if (typeof cleanup === "function") {
-              cleanup();
-            }
-          },
-          useMemo<T>(factory: () => T) {
-            return factory();
-          }
-        };
+        return sharedHooks.react;
       }
 
       if (request === "react/jsx-runtime") {
-        return {
-          jsx(type: unknown, props: Record<string, unknown>, key?: unknown) {
-            return { type, props, key };
-          },
-          jsxs(type: unknown, props: Record<string, unknown>, key?: unknown) {
-            return { type, props, key };
-          },
-          Fragment: Symbol.for("react.fragment")
-        };
+        return sharedHooks.jsxRuntime;
       }
 
       return originalModuleLoad(request, parent, isMain);
@@ -119,6 +273,113 @@ describe("popup entrypoint", () => {
       } else {
         delete globalScope.document;
       }
+    }
+  });
+
+  it("renders stored bookmarks after hydration completes", async () => {
+    const Module = require("module") as {
+      _load: (request: string, parent: unknown, isMain: boolean) => unknown;
+      createRequire: (filename: string) => RequireFunction;
+    };
+    const originalModuleLoad = Module._load;
+    const resolver = Module.createRequire(__filename);
+    const hooks = sharedHooks;
+    hooks.reset();
+
+    Module._load = (request, parent, isMain) => {
+      if (request === "react") {
+        return hooks.react;
+      }
+
+      if (request === "react/jsx-runtime") {
+        return hooks.jsxRuntime;
+      }
+
+      return originalModuleLoad(request, parent, isMain);
+    };
+
+    const storedBookmarks = [
+      {
+        id: "bookmark-1",
+        title: "Persisted example",
+        url: "https://example.com/",
+        category: "General",
+        tags: ["example"],
+        createdAt: "2024-05-01T12:00:00.000Z",
+        source: "chromium" as const
+      },
+      {
+        id: "bookmark-2",
+        title: "Reference docs",
+        url: "https://docs.example.com/",
+        category: "Reference",
+        tags: ["reference"],
+        createdAt: "2024-05-02T08:30:00.000Z",
+        source: "firefox" as const
+      }
+    ];
+
+    const { searchBookmarks } = resolver(
+      "../../domain/services/search"
+    ) as typeof import("../../domain/services/search");
+    const originalHydrateFromStorage = searchBookmarks.hydrateFromStorage;
+    const originalQuery = searchBookmarks.query;
+
+    let visibleBookmarks: typeof storedBookmarks = [];
+    const queryCalls: string[] = [];
+    let resolveHydration: (() => void) | undefined;
+
+    const hydrationPromise = new Promise<void>((resolve) => {
+      resolveHydration = () => {
+        visibleBookmarks = storedBookmarks.map((bookmark) => ({ ...bookmark }));
+        resolve();
+      };
+    });
+
+    searchBookmarks.hydrateFromStorage = () => hydrationPromise;
+    searchBookmarks.query = (term: string) => {
+      queryCalls.push(term);
+      return visibleBookmarks;
+    };
+
+    try {
+      const { App } = await import("../App");
+
+      const initialTree = hooks.render(() => App() as ReactElement);
+
+      assert.ok(resolveHydration);
+
+      const initialList: ReactElement[] = [];
+      collectElements(initialTree, (candidate) => candidate.type === "li", initialList);
+      assert.strictEqual(initialList.length, 0);
+      assert.deepStrictEqual(queryCalls, [""]);
+
+      resolveHydration!();
+      await hydrationPromise;
+
+      const hydratedTree = hooks.getTree();
+      const hydratedItems: ReactElement[] = [];
+      collectElements(hydratedTree, (candidate) => candidate.type === "li", hydratedItems);
+      assert.strictEqual(hydratedItems.length, storedBookmarks.length);
+      assert.deepStrictEqual(queryCalls, ["", ""]);
+
+      hydratedItems.forEach((item, index) => {
+        const anchors: ReactElement[] = [];
+        collectElements(item, (candidate) => candidate.type === "a", anchors);
+        assert.strictEqual(anchors.length, 1);
+        const [anchor] = anchors;
+        assert.strictEqual(anchor.props.href, storedBookmarks[index].url);
+
+        const spans: ReactElement[] = [];
+        collectElements(anchor, (candidate) => candidate.type === "span", spans);
+        assert.strictEqual(spans.length, 2);
+        assert.strictEqual(spans[0].props.children, storedBookmarks[index].title);
+        assert.strictEqual(spans[1].props.children, storedBookmarks[index].category);
+      });
+    } finally {
+      Module._load = originalModuleLoad;
+      searchBookmarks.hydrateFromStorage = originalHydrateFromStorage;
+      searchBookmarks.query = originalQuery;
     }
   });
 });


### PR DESCRIPTION
## Summary
- hydrate the popup search index when the component mounts and re-query once storage data loads
- add a reusable hook-based React stub so the popup test suite can execute effects and state updates
- extend the popup tests with a hydration scenario that stubs the bookmark search service and asserts persisted results render

## Testing
- npm run test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d0c6058dcc832aaa3d6a857630fc25