### PR TITLE
Persist platform secret for bookmark snapshots

### DIFF
--- a/packages/web-extension/src/domain/services/__tests__/search.test.ts
+++ b/packages/web-extension/src/domain/services/__tests__/search.test.ts
@@ -250,9 +250,16 @@ describe("searchBookmarks storage integration", () => {
 
     await searchBookmarks.persistSnapshot();
 
-    assert.strictEqual(calls.length, 2);
+    const snapshotCalls = calls.filter((call) => {
+      return Object.prototype.hasOwnProperty.call(
+        call.items,
+        BOOKMARK_SNAPSHOT_STORAGE_KEY
+      );
+    });
 
-    for (const call of calls) {
+    assert.strictEqual(snapshotCalls.length, 2);
+
+    for (const call of snapshotCalls) {
       const payload = call.items[BOOKMARK_SNAPSHOT_STORAGE_KEY] as Record<string, unknown>;
       assert.ok(payload);
       assert.strictEqual(payload.kind, "encrypted");

--- a/packages/web-extension/src/domain/services/search.ts
+++ b/packages/web-extension/src/domain/services/search.ts
@@ -96,8 +96,23 @@ class SearchIndex {
     }
 
     try {
-      const snapshot = await decryptBookmarkSnapshot(storageValue, context);
+      const { snapshot, migratedPayload } = await decryptBookmarkSnapshot(
+        storageValue,
+        context
+      );
       this.deserialize(snapshot);
+
+      if (migratedPayload) {
+        await setItem(BOOKMARK_SNAPSHOT_STORAGE_KEY, migratedPayload, {
+          area: "local"
+        });
+
+        if (settings.enabled) {
+          await setItem(BOOKMARK_SNAPSHOT_STORAGE_KEY, migratedPayload, {
+            area: "sync"
+          });
+        }
+      }
     } catch (error) {
       console.error("Failed to decrypt bookmark snapshot", error);
       this.deserialize(null);


### PR DESCRIPTION
## Summary
- persist a stable platform secret in extension storage and fall back to the legacy user-agent-derived key when needed
- re-encrypt legacy bookmark snapshots with the new secret and surface the migrated payload to storage consumers
- expand bookmark snapshot crypto tests to cover migration and adjust storage assertions for the extra secret write

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0d284b6a0832a8b93ce82315b1305