### PR TITLE
Fix web extension build output paths

### DIFF
--- a/packages/web-extension/scripts/build.mjs
+++ b/packages/web-extension/scripts/build.mjs
@@ -34,7 +34,7 @@ async function collectEntries() {
 
   for (const candidate of candidates) {
     if (await pathExists(candidate.entryPath)) {
-      const outputKey = candidate.relativePath.replace(/\\.tsx?$/, "");
+      const outputKey = candidate.relativePath.replace(/\.tsx?$/, "");
       entries[outputKey] = candidate.entryPath;
     }
   }


### PR DESCRIPTION
## Summary
- ensure collectEntries strips TypeScript extensions with a regex that matches .ts and .tsx

## Testing
- npm --prefix packages/web-extension run build

------
https://chatgpt.com/codex/tasks/task_e_68d105a90b5c832abeee48bf0110e116