### PR TITLE
Update Docker instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ Run the default `npm run test` command inside the container:
 docker compose run --rm web-extension
 ```
 
-To keep the container alive for repeated runs (for example, while debugging against the exposed Chrome DevTools port 9222), start it in attached mode:
+To keep the container alive for repeated runs (for example, while debugging against the exposed Chrome DevTools port 9222), drop into an interactive shell while keeping service ports exposed:
 
 ```bash
-docker compose up
+docker compose run --rm --service-ports web-extension bash
 ```
 
-Test results are streamed to your terminal output. Repository changes in your local workspace are mounted into the container, so edits on the host are immediately reflected inside Docker.
+From that shell you can launch Chromium manually (for example, `chromium-browser --remote-debugging-port=9222`) so the DevTools port stays open, or run any npm scripts you need. Command output streams directly to your terminal. Repository changes in your local workspace are mounted into the container, so edits on the host are immediately reflected inside Docker.
 
 For a one-step wrapper, use the optional helper script:
 


### PR DESCRIPTION
## Summary
- replace the attached `docker compose up` guidance with an interactive shell command that keeps service ports exposed
- note that Chromium can be launched manually from that shell to keep the DevTools port open

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d3388cf774832a918295c800273173