### PR TITLE
Document Chromium remote allow origins flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To keep the container alive for repeated runs (for example, while debugging agai
 docker compose run --rm --service-ports web-extension bash
 ```
 
-From that shell you can launch Chromium manually (for example, `chromium-browser --remote-debugging-port=9222`) so the DevTools port stays open, or run any npm scripts you need. Command output streams directly to your terminal. Repository changes in your local workspace are mounted into the container, so edits on the host are immediately reflected inside Docker.
+From that shell you can launch Chromium manually—e.g., `chromium-browser --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222 --remote-allow-origins=*`—so the DevTools port stays open, or run any npm scripts you need. Chromium requires the `--remote-allow-origins=*` flag because connections from the Docker host are not treated as loopback traffic. Command output streams directly to your terminal. Repository changes in your local workspace are mounted into the container, so edits on the host are immediately reflected inside Docker.
 
 For a one-step wrapper, use the optional helper script:
 


### PR DESCRIPTION
## Summary
- update the Docker README instructions with a Chromium sample command that includes remote debugging and remote allow origins flags
- note that the remote allow origins flag is necessary because Docker host connections are not treated as loopback by Chromium

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d339275264832a8588acd86fedff81