### PR TITLE
Document required Chromium flags for Docker debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To keep the container alive for repeated runs (for example, while debugging agai
 docker compose run --rm --service-ports web-extension bash
 ```
 
-From that shell you can launch Chromium manually—e.g., `chromium-browser --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222 --remote-allow-origins=*`—so the DevTools port stays open, or run any npm scripts you need. Chromium requires the `--remote-allow-origins=*` flag because connections from the Docker host are not treated as loopback traffic. Command output streams directly to your terminal. Repository changes in your local workspace are mounted into the container, so edits on the host are immediately reflected inside Docker.
+From that shell you can launch Chromium manually—e.g., `chromium --no-sandbox --headless=new --disable-gpu --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222 --remote-allow-origins=*`—so the DevTools port stays open, or run any npm scripts you need. Chromium requires the `--remote-allow-origins=*` flag because connections from the Docker host are not treated as loopback traffic. The container runs Chromium as the root user without an attached display, so disabling the sandbox and forcing headless mode avoids startup failures caused by Chrome refusing to use GPU acceleration or create a UI session under those conditions. Command output streams directly to your terminal. Repository changes in your local workspace are mounted into the container, so edits on the host are immediately reflected inside Docker.
 
 For a one-step wrapper, use the optional helper script:
 


### PR DESCRIPTION
## Summary
- update the Docker debugging instructions to launch the correct Chromium binary
- document the required no-sandbox and headless flags to avoid container startup failures

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d33b922408832ab6ae15c01d3562d7