### PR TITLE
Add zip archive creation to extension packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ packages/web-extension/node_modules/
 # Build outputs
 packages/web-extension/dist/
 packages/web-extension/.tsbuildinfo
+packages/web-extension/capybara-extension-*.zip

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -5,7 +5,7 @@ Capybara is still early in development, so operational practices focus on mainta
 ## Local Development
 
 1. Install dependencies inside `packages/web-extension` with `npm install`.
-2. Run `npm run build` to type-check and bundle assets into `dist/`; keep a second terminal on `node --watch ./scripts/build.mjs` for automatic rebuilds while iterating.
+2. Run `npm run build && npm run package` to type-check, bundle assets into `dist/`, and create `packages/web-extension/capybara-extension-v<version>.zip`; keep a second terminal on `node --watch ./scripts/build.mjs` for automatic rebuilds while iterating.
 3. Load the generated extension directory into Chromium-based browsers via the Extensions page in developer mode.
 
 ## Quality Gates

--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -5,6 +5,7 @@
   "type": "commonjs",
   "scripts": {
     "build": "tsc --noEmit --project tsconfig.json && node ./scripts/build.mjs",
+    "package": "node ../../scripts/package-extension.js",
     "verify:jsx": "node ./scripts/verify-jsx-build.mjs",
     "test": "npm run build --silent && tsx --test src/domain/services/__tests__/*.test.ts src/background/bookmark-sync/__tests__/*.test.ts src/background/__tests__/*.test.ts src/options/__tests__/*.test.ts src/popup/__tests__/*.test.ts"
   },

--- a/scripts/package-extension.js
+++ b/scripts/package-extension.js
@@ -2,6 +2,174 @@
 
 const fs = require("fs/promises");
 const path = require("path");
+const zlib = require("node:zlib");
+const { promisify } = require("node:util");
+
+const deflateRaw = promisify(zlib.deflateRaw);
+
+const CRC32_TABLE = (() => {
+  const table = new Uint32Array(256);
+
+  for (let index = 0; index < 256; index += 1) {
+    let value = index;
+
+    for (let bit = 0; bit < 8; bit += 1) {
+      if ((value & 1) === 1) {
+        value = 0xedb88320 ^ (value >>> 1);
+      } else {
+        value >>>= 1;
+      }
+    }
+
+    table[index] = value >>> 0;
+  }
+
+  return table;
+})();
+
+function crc32(buffer) {
+  let crc = 0 ^ -1;
+
+  for (const byte of buffer) {
+    crc = (crc >>> 8) ^ CRC32_TABLE[(crc ^ byte) & 0xff];
+  }
+
+  return (crc ^ -1) >>> 0;
+}
+
+function toDosDateTime(date) {
+  const safeYear = Math.max(date.getFullYear(), 1980);
+  const dosTime =
+    (date.getHours() << 11) |
+    (date.getMinutes() << 5) |
+    Math.floor(date.getSeconds() / 2);
+  const dosDate =
+    ((safeYear - 1980) << 9) |
+    ((date.getMonth() + 1) << 5) |
+    date.getDate();
+
+  return { dosDate, dosTime };
+}
+
+async function collectFiles(rootDirectory, currentDirectory = rootDirectory) {
+  const entries = await fs.readdir(currentDirectory, { withFileTypes: true });
+  const sortedEntries = entries.sort((left, right) =>
+    left.name.localeCompare(right.name)
+  );
+  const files = [];
+
+  for (const entry of sortedEntries) {
+    const absolutePath = path.join(currentDirectory, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await collectFiles(rootDirectory, absolutePath)));
+    } else if (entry.isFile()) {
+      files.push({
+        absolutePath,
+        relativePath: path.relative(rootDirectory, absolutePath),
+      });
+    }
+  }
+
+  return files;
+}
+
+async function createZipArchive(sourceDirectory, outputFile) {
+  const files = await collectFiles(sourceDirectory);
+
+  const localFileChunks = [];
+  const centralDirectoryEntries = [];
+  let localEntriesSize = 0;
+
+  for (const file of files) {
+    const fileName = file.relativePath.split(path.sep).join("/");
+    const fileNameBuffer = Buffer.from(fileName, "utf8");
+    const data = await fs.readFile(file.absolutePath);
+    const compressedData = await deflateRaw(data, {
+      level: zlib.constants.Z_BEST_COMPRESSION,
+    });
+    const crc = crc32(data);
+    const stats = await fs.stat(file.absolutePath);
+    const { dosDate, dosTime } = toDosDateTime(stats.mtime);
+
+    const localHeader = Buffer.alloc(30);
+    localHeader.writeUInt32LE(0x04034b50, 0);
+    localHeader.writeUInt16LE(20, 4);
+    localHeader.writeUInt16LE(0, 6);
+    localHeader.writeUInt16LE(8, 8);
+    localHeader.writeUInt16LE(dosTime, 10);
+    localHeader.writeUInt16LE(dosDate, 12);
+    localHeader.writeUInt32LE(crc, 14);
+    localHeader.writeUInt32LE(compressedData.length, 18);
+    localHeader.writeUInt32LE(data.length, 22);
+    localHeader.writeUInt16LE(fileNameBuffer.length, 26);
+    localHeader.writeUInt16LE(0, 28);
+
+    const localHeaderOffset = localEntriesSize;
+    localEntriesSize += localHeader.length + fileNameBuffer.length + compressedData.length;
+
+    localFileChunks.push(localHeader, fileNameBuffer, compressedData);
+    centralDirectoryEntries.push({
+      compressedSize: compressedData.length,
+      crc,
+      dosDate,
+      dosTime,
+      fileNameBuffer,
+      localHeaderOffset,
+      uncompressedSize: data.length,
+    });
+  }
+
+  const centralDirectoryOffset = localEntriesSize;
+  const centralDirectoryChunks = [];
+  let centralDirectorySize = 0;
+
+  for (const entry of centralDirectoryEntries) {
+    const centralHeader = Buffer.alloc(46);
+    centralHeader.writeUInt32LE(0x02014b50, 0);
+    centralHeader.writeUInt16LE(0x0014, 4);
+    centralHeader.writeUInt16LE(20, 6);
+    centralHeader.writeUInt16LE(0, 8);
+    centralHeader.writeUInt16LE(8, 10);
+    centralHeader.writeUInt16LE(entry.dosTime, 12);
+    centralHeader.writeUInt16LE(entry.dosDate, 14);
+    centralHeader.writeUInt32LE(entry.crc, 16);
+    centralHeader.writeUInt32LE(entry.compressedSize, 20);
+    centralHeader.writeUInt32LE(entry.uncompressedSize, 24);
+    centralHeader.writeUInt16LE(entry.fileNameBuffer.length, 28);
+    centralHeader.writeUInt16LE(0, 30);
+    centralHeader.writeUInt16LE(0, 32);
+    centralHeader.writeUInt16LE(0, 34);
+    centralHeader.writeUInt16LE(0, 36);
+    centralHeader.writeUInt32LE(0, 38);
+    centralHeader.writeUInt32LE(entry.localHeaderOffset, 42);
+
+    centralDirectoryChunks.push(centralHeader, entry.fileNameBuffer);
+    centralDirectorySize += centralHeader.length + entry.fileNameBuffer.length;
+  }
+
+  const endOfCentralDirectory = Buffer.alloc(22);
+  endOfCentralDirectory.writeUInt32LE(0x06054b50, 0);
+  endOfCentralDirectory.writeUInt16LE(0, 4);
+  endOfCentralDirectory.writeUInt16LE(0, 6);
+  endOfCentralDirectory.writeUInt16LE(centralDirectoryEntries.length, 8);
+  endOfCentralDirectory.writeUInt16LE(centralDirectoryEntries.length, 10);
+  endOfCentralDirectory.writeUInt32LE(centralDirectorySize, 12);
+  endOfCentralDirectory.writeUInt32LE(centralDirectoryOffset, 16);
+  endOfCentralDirectory.writeUInt16LE(0, 20);
+
+  const totalSize =
+    localEntriesSize + centralDirectorySize + endOfCentralDirectory.length;
+  const buffers = [
+    ...localFileChunks,
+    ...centralDirectoryChunks,
+    endOfCentralDirectory,
+  ];
+  const zipBuffer = Buffer.concat(buffers, totalSize);
+
+  await fs.rm(outputFile, { force: true });
+  await fs.writeFile(outputFile, zipBuffer);
+}
 
 async function pathExists(targetPath) {
   try {
@@ -76,6 +244,7 @@ async function main() {
     "packages",
     "web-extension"
   );
+  const packageJsonPath = path.join(extensionPackageRoot, "package.json");
   const manifestPath = path.join(extensionPackageRoot, "manifest.json");
   const publicDirectory = path.join(extensionPackageRoot, "public");
   const distDirectory = path.join(extensionPackageRoot, "dist");
@@ -98,10 +267,31 @@ async function main() {
   await copyPublicAssets(publicDirectory, extensionDirectory);
   await copyDirectory(distDirectory, path.join(extensionDirectory, "dist"));
 
+  const packageDefinition = JSON.parse(
+    await fs.readFile(packageJsonPath, "utf8")
+  );
+  const version = packageDefinition.version;
+
+  if (typeof version !== "string" || version.trim() === "") {
+    throw new Error("Extension package version is missing from package.json");
+  }
+
+  const archivePath = path.join(
+    extensionPackageRoot,
+    `capybara-extension-v${version}.zip`
+  );
+  await createZipArchive(extensionDirectory, archivePath);
+
   console.log(
     `Packaged extension assets into ${path.relative(
       repositoryRoot,
       extensionDirectory
+    )}`
+  );
+  console.log(
+    `Compressed extension archive available at ${path.relative(
+      repositoryRoot,
+      archivePath
     )}`
   );
 }


### PR DESCRIPTION
## Summary
- extend the packaging helper to build a versioned zip archive of the extension using Node's zlib primitives
- expose an npm `package` script in the web-extension package and document the combined build+package workflow and artifact location
- ignore generated zip archives to keep the repository clean after packaging runs

## Testing
- `npm run package` *(fails: `npm`/`node` are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3454e40a8832a8bf4dff7eac9e865