### PR TITLE
Add lint workflow for web extension

### DIFF
--- a/.github/workflows/web-extension.yml
+++ b/.github/workflows/web-extension.yml
@@ -22,5 +22,6 @@ jobs:
         with:
           node-version: 20
       - run: npm install
-      - run: npm run build
+      - run: npm run lint
+      - run: npm run test
       - run: npm run verify:jsx

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -5,13 +5,14 @@ Capybara is still early in development, so operational practices focus on mainta
 ## Local Development
 
 1. Install dependencies inside `packages/web-extension` with `npm install`.
-2. Run `npm run build && npm run package` to type-check, bundle assets into `dist/`, and create `packages/web-extension/capybara-extension-v<version>.zip`; keep a second terminal on `node --watch ./scripts/build.mjs` for automatic rebuilds while iterating.
-3. Load the generated extension directory into Chromium-based browsers via the Extensions page in developer mode.
+2. Run `npm run lint && npm run test` to execute static analysis and the TypeScript test suite before iterating on manual checks.
+3. Run `npm run build && npm run package` to type-check, bundle assets into `dist/`, and create `packages/web-extension/capybara-extension-v<version>.zip`; keep a second terminal on `node --watch ./scripts/build.mjs` for automatic rebuilds while iterating.
+4. Load the generated extension directory into Chromium-based browsers via the Extensions page in developer mode.
 
 ## Quality Gates
 
+- Run `npm run lint && npm run test` before merging changes to enforce the linting and unit test gates.
 - Unit tests should be colocated with the domain services once their behavior stabilizes.
-- Linting via `eslint` will help enforce React and TypeScript conventions; introduce it before shipping the first public beta.
 - Manual smoke tests must include background sync, popup queries, and options toggles.
 
 ## Release Checklist

--- a/packages/web-extension/eslint.config.js
+++ b/packages/web-extension/eslint.config.js
@@ -1,0 +1,4 @@
+module.exports = (async () => {
+  const configModule = await import("./eslint.config.mjs");
+  return configModule.default;
+})();

--- a/packages/web-extension/eslint.config.mjs
+++ b/packages/web-extension/eslint.config.mjs
@@ -1,0 +1,73 @@
+import js from "@eslint/js";
+import { FlatCompat } from "@eslint/eslintrc";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import tseslint from "typescript-eslint";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  resolvePluginsRelativeTo: __dirname
+});
+
+const typeCheckedConfigs = tseslint.configs.recommendedTypeChecked.map((config) => ({
+  ...config,
+  files: ["src/**/*.{ts,tsx}"],
+  languageOptions: {
+    ...config.languageOptions,
+    parserOptions: {
+      ...(config.languageOptions?.parserOptions ?? {}),
+      project: "./tsconfig.json",
+      tsconfigRootDir: __dirname,
+      ecmaFeatures: {
+        ...(config.languageOptions?.parserOptions?.ecmaFeatures ?? {}),
+        jsx: true
+      }
+    }
+  }
+}));
+
+const reactConfigs = compat
+  .extends(
+    "plugin:react/recommended",
+    "plugin:react/jsx-runtime",
+    "plugin:react-hooks/recommended",
+    "plugin:jsx-a11y/recommended"
+  )
+  .map((config) => ({
+    ...config,
+    files: ["src/**/*.{ts,tsx}"]
+  }));
+
+export default tseslint.config(
+  {
+    ignores: ["dist/**", "scripts/**"]
+  },
+  {
+    ...js.configs.recommended,
+    files: ["src/**/*.{ts,tsx}"]
+  },
+  ...typeCheckedConfigs,
+  ...reactConfigs,
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    languageOptions: {
+      parserOptions: {
+        project: "./tsconfig.json",
+        tsconfigRootDir: __dirname,
+        ecmaFeatures: { jsx: true }
+      }
+    },
+    settings: {
+      react: {
+        version: "detect"
+      }
+    },
+    globals: {
+      chrome: "readonly",
+      browser: "readonly"
+    }
+  }
+);

--- a/packages/web-extension/package-lock.json
+++ b/packages/web-extension/package-lock.json
@@ -12,11 +12,20 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
+        "@eslint/eslintrc": "^3.1.0",
+        "@eslint/js": "^9.4.0",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
+        "@typescript-eslint/eslint-plugin": "^7.13.0",
+        "@typescript-eslint/parser": "^7.13.0",
         "esbuild": "^0.21.5",
+        "eslint": "^9.4.0",
+        "eslint-plugin-jsx-a11y": "^6.8.0",
+        "eslint-plugin-react": "^7.34.2",
+        "eslint-plugin-react-hooks": "^4.6.0",
         "tsx": "^4.7.0",
-        "typescript": "^5.4.0"
+        "typescript": "^5.4.0",
+        "typescript-eslint": "^7.13.0"
       }
     },
     "node_modules/@esbuild/linux-x64": {

--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -5,6 +5,7 @@
   "type": "commonjs",
   "scripts": {
     "build": "tsc --noEmit --project tsconfig.json && node ./scripts/build.mjs",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "package": "node ../../scripts/package-extension.js",
     "verify:jsx": "node ./scripts/verify-jsx-build.mjs",
     "test": "npm run build --silent && tsx --test src/domain/services/__tests__/*.test.ts src/background/bookmark-sync/__tests__/*.test.ts src/background/__tests__/*.test.ts src/options/__tests__/*.test.ts src/popup/__tests__/*.test.ts"
@@ -14,10 +15,19 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.1.0",
+    "@eslint/js": "^9.4.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
+    "@typescript-eslint/eslint-plugin": "^7.13.0",
+    "@typescript-eslint/parser": "^7.13.0",
     "esbuild": "^0.21.5",
+    "eslint": "^9.4.0",
+    "eslint-plugin-jsx-a11y": "^6.8.0",
+    "eslint-plugin-react": "^7.34.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "tsx": "^4.7.0",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "typescript-eslint": "^7.13.0"
   }
 }


### PR DESCRIPTION
## Summary
- add an ESLint flat config for the web extension with React and TypeScript presets
- expose an npm lint script and teach CI to run linting before the test suite
- document the lint-and-test gate in the operations runbook

## Testing
- npm install *(fails: 403 Forbidden when fetching @typescript-eslint packages)*
- npm run lint *(fails: missing locally-installed ESLint dependencies in the sandbox)*
- npm run test *(fails: missing esbuild dependency in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d3eeefe560832abd2a74932dc4cd7c