### PR TITLE
feat: add docker demo workflow for extension preview

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,5 @@ RUN cd packages/web-extension && npm install
 # Default working directory for runtime commands
 WORKDIR /usr/src/app/packages/web-extension
 
-# Run the test suite by default when the container starts
-CMD ["npm", "run", "test"]
+# Run the interactive demo by default when the container starts
+CMD ["npm", "run", "demo"]

--- a/README.md
+++ b/README.md
@@ -61,21 +61,31 @@ docker compose build
 
 ### Execute the test suite
 
-Run the default `npm run test` command inside the container:
+Run the demo server and headless Chromium target with:
 
 ```bash
-docker compose run --rm web-extension
+docker compose up web-extension
 ```
 
-To keep the container alive for repeated runs (for example, while debugging against the exposed Chrome DevTools port 9222), drop into an interactive shell while keeping service ports exposed:
+The container builds the extension bundle, serves the static assets on <http://127.0.0.1:4173>, and launches Chromium in headless mode with remote debugging exposed on port `9222`. Visit <http://127.0.0.1:4173/popup/> for the popup UI or <http://127.0.0.1:4173/options/> for the options screen. To attach your local browser to the headless instance, open `chrome://inspect`, add `127.0.0.1:9222` as a target, and inspect the running context. Chromium logs several DBus warnings at startup inside the container—these are expected because no desktop session is available.
+
+### Execute the test suite
+
+Run the default `npm run test` command inside the container whenever you need the automated checks:
+
+```bash
+docker compose run --rm web-extension npm run test
+```
+
+To keep the container alive for repeated runs or manual inspection, drop into an interactive shell while keeping service ports exposed:
 
 ```bash
 docker compose run --rm --service-ports web-extension bash
 ```
 
-From that shell you can launch Chromium manually—e.g., `chromium --no-sandbox --headless=new --disable-gpu --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222 --remote-allow-origins=*`—so the DevTools port stays open, or run any npm scripts you need. Chromium requires the `--remote-allow-origins=*` flag because connections from the Docker host are not treated as loopback traffic. The container runs Chromium as the root user without an attached display, so disabling the sandbox and forcing headless mode avoids startup failures caused by Chrome refusing to use GPU acceleration or create a UI session under those conditions. Command output streams directly to your terminal. Repository changes in your local workspace are mounted into the container, so edits on the host are immediately reflected inside Docker.
+From that shell you can call `npm run demo` to start the preview server and Chromium, run `npm run build` to rebuild the distributable bundle, or execute any other npm script. Repository changes in your local workspace are mounted into the container, so edits on the host are immediately reflected inside Docker.
 
-For a one-step wrapper, use the optional helper script:
+For a one-step wrapper around the test workflow, use the optional helper script:
 
 ```bash
 ./scripts/run-docker-tests.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,12 @@ services:
     build:
       context: .
     working_dir: /usr/src/app/packages/web-extension
-    command: npm run test
+    command: npm run demo
     volumes:
       - .:/usr/src/app
       - node_modules:/usr/src/app/packages/web-extension/node_modules
     ports:
+      - "4173:4173"
       - "9222:9222"
 volumes:
   node_modules:

--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -8,6 +8,8 @@
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "package": "node ../../scripts/package-extension.js",
     "verify:jsx": "node ./scripts/verify-jsx-build.mjs",
+    "serve": "node ./scripts/serve.mjs",
+    "demo": "node ./scripts/demo.mjs",
     "test": "npm run build --silent && tsx --test src/domain/services/__tests__/*.test.ts src/background/bookmark-sync/__tests__/*.test.ts src/background/__tests__/*.test.ts src/options/__tests__/*.test.ts src/popup/__tests__/*.test.ts"
   },
   "dependencies": {

--- a/packages/web-extension/scripts/demo.mjs
+++ b/packages/web-extension/scripts/demo.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import process from "node:process";
+
+const defaultPreviewPort = "4173";
+const defaultDebugPort = "9222";
+const previewPort = process.env.PREVIEW_PORT ?? defaultPreviewPort;
+const debugPort = process.env.DEBUG_PORT ?? defaultDebugPort;
+
+function spawnProcess(command, args, options = {}) {
+  const child = spawn(command, args, { stdio: "inherit", ...options });
+
+  child.on("error", (error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Failed to launch ${command}: ${message}`);
+  });
+
+  return child;
+}
+
+function waitFor(child) {
+  return new Promise((resolve, reject) => {
+    child.once("exit", (code, signal) => resolve({ code, signal }));
+    child.once("error", (error) => reject(error));
+  });
+}
+
+async function main() {
+  const serveEnv = { ...process.env, PREVIEW_PORT: previewPort };
+  const serve = spawnProcess("npm", ["run", "serve", "--silent"], { env: serveEnv });
+
+  console.log("");
+  console.log(`Launching headless Chromium with remote debugging on port ${debugPort}...`);
+  console.log("Use chrome://inspect in your host browser and add a target with the exposed port to attach to the session.");
+
+  let chromiumExitCode = 0;
+  const chromiumArgs = [
+    "--no-sandbox",
+    "--headless=new",
+    "--disable-gpu",
+    "--disable-dev-shm-usage",
+    "--remote-debugging-address=0.0.0.0",
+    `--remote-debugging-port=${debugPort}`,
+    "--remote-allow-origins=*",
+  ];
+  const chromium = spawnProcess("chromium", chromiumArgs);
+
+  const serveExitPromise = waitFor(serve);
+  const chromiumExitPromise = waitFor(chromium).then(({ code, signal }) => {
+    if (signal && signal !== "SIGTERM" && signal !== "SIGINT") {
+      console.error(`Chromium exited due to signal ${signal}`);
+    }
+
+    if (typeof code === "number" && code !== 0) {
+      console.error(`Chromium exited with status ${code}`);
+      chromiumExitCode = code;
+      if (!serve.killed) {
+        console.error("Stopping preview server because Chromium is no longer running.");
+        serve.kill("SIGTERM");
+      }
+    }
+  }).catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    if (!serve.killed) {
+      serve.kill("SIGTERM");
+    }
+    chromiumExitCode = 1;
+  });
+
+  const stopProcesses = () => {
+    if (!serve.killed) {
+      serve.kill("SIGTERM");
+    }
+
+    if (!chromium.killed) {
+      chromium.kill("SIGTERM");
+    }
+  };
+
+  process.once("SIGINT", stopProcesses);
+  process.once("SIGTERM", stopProcesses);
+
+  const { code: serveCode, signal: serveSignal } = await serveExitPromise.catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    return { code: 1, signal: null };
+  });
+
+  stopProcesses();
+  await chromiumExitPromise;
+
+  if (typeof serveSignal === "string" && (serveSignal === "SIGINT" || serveSignal === "SIGTERM")) {
+    process.exit(0);
+  }
+
+  if (typeof serveCode === "number" && serveCode !== 0) {
+    process.exit(serveCode);
+  }
+
+  if (chromiumExitCode !== 0) {
+    process.exit(chromiumExitCode);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/packages/web-extension/scripts/serve.mjs
+++ b/packages/web-extension/scripts/serve.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import http from "node:http";
+import path from "node:path";
+import process from "node:process";
+
+const projectRoot = process.cwd();
+const distDirectory = path.join(projectRoot, "dist");
+const defaultPort = 4173;
+const port = Number.parseInt(process.env.PREVIEW_PORT ?? String(defaultPort), 10);
+const host = "0.0.0.0";
+
+const mimeTypes = new Map([
+  [".html", "text/html; charset=utf-8"],
+  [".js", "application/javascript; charset=utf-8"],
+  [".mjs", "application/javascript; charset=utf-8"],
+  [".css", "text/css; charset=utf-8"],
+  [".json", "application/json; charset=utf-8"],
+  [".svg", "image/svg+xml"],
+  [".png", "image/png"],
+  [".jpg", "image/jpeg"],
+  [".jpeg", "image/jpeg"],
+  [".gif", "image/gif"],
+  [".ico", "image/x-icon"],
+  [".map", "application/json; charset=utf-8"],
+]);
+
+function runBuild() {
+  return new Promise((resolve, reject) => {
+    const build = spawn("npm", ["run", "build", "--silent"], {
+      cwd: projectRoot,
+      stdio: "inherit",
+      env: process.env,
+    });
+
+    build.on("error", (error) => {
+      reject(new Error(`Failed to launch build: ${error instanceof Error ? error.message : String(error)}`));
+    });
+
+    build.on("exit", (code, signal) => {
+      if (signal) {
+        reject(new Error(`Build terminated by signal ${signal}`));
+        return;
+      }
+
+      if (typeof code === "number" && code !== 0) {
+        reject(new Error(`Build exited with status ${code}`));
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+async function resolveFilePath(requestedPath) {
+  const normalizedPath = path.posix.normalize(requestedPath);
+  const relativePath = normalizedPath.startsWith("/")
+    ? normalizedPath.slice(1)
+    : normalizedPath;
+  const resolvedPath = path.resolve(distDirectory, relativePath);
+
+  const relativeToDist = path.relative(distDirectory, resolvedPath);
+
+  if (relativeToDist.startsWith("..") || path.isAbsolute(relativeToDist)) {
+    return null;
+  }
+
+  let candidatePath = resolvedPath;
+  let fileStats = await stat(candidatePath).catch(() => null);
+
+  if (fileStats?.isDirectory()) {
+    const indexPath = path.join(candidatePath, "index.html");
+    const indexStats = await stat(indexPath).catch(() => null);
+
+    if (indexStats?.isFile()) {
+      return indexPath;
+    }
+
+    return null;
+  }
+
+  if (fileStats?.isFile()) {
+    return candidatePath;
+  }
+
+  const htmlFallback = `${resolvedPath}.html`;
+  const htmlStats = await stat(htmlFallback).catch(() => null);
+
+  if (htmlStats?.isFile()) {
+    return htmlFallback;
+  }
+
+  return null;
+}
+
+async function handleRequest(request, response) {
+  const method = request.method?.toUpperCase();
+
+  if (method && method !== "GET" && method !== "HEAD") {
+    response.statusCode = 405;
+    response.setHeader("Allow", "GET, HEAD");
+    response.end("Method Not Allowed");
+    return;
+  }
+
+  const fallbackHost = `localhost:${Number.isFinite(port) ? port : defaultPort}`;
+  const requestUrl = new URL(request.url ?? "/", `http://${request.headers.host ?? fallbackHost}`);
+
+  if (requestUrl.pathname === "/") {
+    response.statusCode = 302;
+    response.setHeader("Location", "/popup/");
+    response.end();
+    return;
+  }
+
+  const filePath = await resolveFilePath(requestUrl.pathname).catch(() => null);
+
+  if (!filePath) {
+    response.statusCode = 404;
+    response.end("Not Found");
+    return;
+  }
+
+  const fileExtension = path.extname(filePath).toLowerCase();
+  const contentType = mimeTypes.get(fileExtension) ?? "application/octet-stream";
+
+  response.statusCode = 200;
+  response.setHeader("Content-Type", contentType);
+  response.setHeader("Cache-Control", "no-store");
+
+  if (method === "HEAD") {
+    response.end();
+    return;
+  }
+
+  const stream = createReadStream(filePath);
+
+  stream.on("error", (error) => {
+    response.destroy(error);
+  });
+
+  stream.pipe(response);
+}
+
+async function main() {
+  if (!Number.isFinite(port)) {
+    console.warn(`Invalid PREVIEW_PORT value: ${process.env.PREVIEW_PORT}. Falling back to ${defaultPort}.`);
+  }
+
+  await runBuild();
+
+  const server = http.createServer((request, response) => {
+    handleRequest(request, response).catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      response.statusCode = 500;
+      response.setHeader("Content-Type", "text/plain; charset=utf-8");
+      response.end(`Internal Server Error\n${message}`);
+    });
+  });
+
+  server.listen(Number.isFinite(port) ? port : defaultPort, host, () => {
+    const listenPort = Number.isFinite(port) ? port : defaultPort;
+    console.log("");
+    console.log(`Capybara preview server listening on http://localhost:${listenPort}`);
+    console.log(`Popup UI: http://localhost:${listenPort}/popup/`);
+    console.log(`Options UI: http://localhost:${listenPort}/options/`);
+    console.log("Press Ctrl+C to stop the server.");
+  });
+
+  const closeServer = () => {
+    server.close(() => {
+      process.exit(0);
+    });
+  };
+
+  process.on("SIGINT", closeServer);
+  process.on("SIGTERM", closeServer);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/run-docker-tests.sh
+++ b/scripts/run-docker-tests.sh
@@ -20,5 +20,5 @@ fi
 if [ "$#" -gt 0 ]; then
   exec "${COMPOSE_COMMAND[@]}" -f "$COMPOSE_FILE" run --rm "$SERVICE_NAME" "$@"
 else
-  exec "${COMPOSE_COMMAND[@]}" -f "$COMPOSE_FILE" run --rm "$SERVICE_NAME"
+  exec "${COMPOSE_COMMAND[@]}" -f "$COMPOSE_FILE" run --rm "$SERVICE_NAME" npm run test
 fi


### PR DESCRIPTION
## Summary
- add npm scripts that build the extension bundle, serve the static UI, and launch headless Chromium for demos
- expose the preview workflow through the Dockerfile/compose service and document how to reach the popup and options pages
- adjust the helper script so docker-based test runs continue to invoke the automated suite by default

## Testing
- npm run test *(fails: dependencies cannot be installed because access to the npm registry is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f64b3978832a928d82bc54ebbb95