### PR TITLE
Add module type attribute to web extension scripts

### DIFF
--- a/packages/web-extension/public/options.html
+++ b/packages/web-extension/public/options.html
@@ -6,6 +6,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script src="./index.js" defer></script>
+    <script src="./index.js" type="module" defer></script>
   </body>
 </html>

--- a/packages/web-extension/public/popup.html
+++ b/packages/web-extension/public/popup.html
@@ -6,6 +6,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script src="./index.js" defer></script>
+    <script src="./index.js" type="module" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add `type="module"` to the popup and options HTML entry scripts so the ESM bundle can load correctly

## Testing
- `npm run build` *(fails: missing dev dependency esbuild because packages cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d437a8e704832a9ac2d1d2b79f837c