### PR TITLE
feat(extension): mark background worker as module

### DIFF
--- a/packages/web-extension/manifest.json
+++ b/packages/web-extension/manifest.json
@@ -18,7 +18,8 @@
     "128": "icons/icon-128.png"
   },
   "background": {
-    "service_worker": "dist/background/index.js"
+    "service_worker": "dist/background/index.js",
+    "type": "module"
   },
   "options_ui": {
     "page": "dist/options/index.html",


### PR DESCRIPTION
## Summary
- declare the background service worker as an ES module in the extension manifest

## Testing
- npm run package *(fails: repository root has no package.json)*
- npm run build *(fails: missing esbuild dependency because npm install is blocked by registry permissions)*
- npm install *(fails: registry returned 403 for required packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d43d5512d0832aad59cbccd95540e9