### PR TITLE
chore: update typescript version for web extension

### DIFF
--- a/packages/web-extension/package-lock.json
+++ b/packages/web-extension/package-lock.json
@@ -24,7 +24,7 @@
         "eslint-plugin-react": "^7.34.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "tsx": "^4.7.0",
-        "typescript": "^5.4.0",
+        "typescript": "^5.6.3",
         "typescript-eslint": "^7.13.0"
       }
     },
@@ -122,7 +122,7 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.4.0",
+      "version": "5.6.3",
       "dev": true
     }
   }

--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -29,7 +29,7 @@
     "eslint-plugin-react": "^7.34.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "tsx": "^4.7.0",
-    "typescript": "^5.4.0",
+    "typescript": "^5.6.3",
     "typescript-eslint": "^7.13.0"
   }
 }


### PR DESCRIPTION
## Summary
- update the TypeScript devDependency in the web extension package to the newer ^5.6.3 release
- synchronize the package-lock entry so the resolved TypeScript version matches the dependency specification

## Testing
- npm install *(fails: 403 Forbidden from registry.npmjs.org in this environment)*
- docker compose build *(fails: `docker` CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d446477914832a87719bfb5844524a